### PR TITLE
chore(main): revert release google-cloud-spanner 2.16.1

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,3 +1,3 @@
 {
-  "google-cloud-spanner": "2.16.1"
+  "google-cloud-spanner": "2.16.0"
 }

--- a/google-cloud-spanner/CHANGELOG.md
+++ b/google-cloud-spanner/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Release History
 
-### 2.16.1 (2022-10-31)
-
-#### Documentation
-
-* Update gemspace and documentation ([#14](https://github.com/googleapis/ruby-spanner/issues/14)) 
-
 ### 2.16.0 (2022-10-25)
 
 #### Features

--- a/google-cloud-spanner/lib/google/cloud/spanner/version.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Spanner
-      VERSION = "2.16.1".freeze
+      VERSION = "2.16.0".freeze
     end
   end
 end


### PR DESCRIPTION
Reverts googleapis/ruby-spanner#22