### PR TITLE
chore(spanner): add rst_stream retry to transaction

### DIFF
--- a/google-cloud-spanner/lib/google/cloud/spanner/client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/client.rb
@@ -1816,7 +1816,7 @@ module Google
               resp = CommitResponse.from_grpc commit_resp
               commit_options ? resp : resp.timestamp
             rescue GRPC::Aborted,
-                   Google::Cloud::AbortedError, 
+                   Google::Cloud::AbortedError,
                    GRPC::Internal,
                    Google::Cloud::InternalError => e
               raise e if internal_error_and_not_retryable? e
@@ -2272,10 +2272,10 @@ module Google
           nil
         end
 
-        def internal_error_and_not_retryable? e
-          (e.instance_of?(Google::Cloud::InternalError) ||
-          e.instance_of?(GRPC::Internal)) &&
-          !@project.service.retryable?(e)  
+        def internal_error_and_not_retryable? error
+          (error.instance_of?(Google::Cloud::InternalError) ||
+          error.instance_of?(GRPC::Internal)) &&
+            !@project.service.retryable?(error)
         end
       end
     end

--- a/google-cloud-spanner/lib/google/cloud/spanner/results.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/results.rb
@@ -41,8 +41,6 @@ module Google
       #   end
       #
       class Results
-        RST_STREAM_INTERNAL_ERROR = "Received RST_STREAM".freeze
-        EOS_INTERNAL_ERROR = "Received unexpected EOS on DATA frame from server".freeze
         ##
         # The read timestamp chosen for single-use snapshots (read-only
         # transactions).
@@ -177,7 +175,7 @@ module Google
 
               if resumable?(resume_token)
                 should_resume_request = true
-              elsif retryable?(err)
+              elsif @service.retryable?(err)
                 should_retry_request = true
               elsif err.is_a?(Google::Cloud::Error)
                 raise err
@@ -227,21 +225,6 @@ module Google
           resume_token && !resume_token.empty?
         end
 
-        ##
-        # @private
-        # Checks if a request can be retried. This is based on the error returned.
-        # Retryable errors are:
-        #   - Unavailable error
-        #   - Internal EOS error
-        #   - Internal RST_STREAM error
-        def retryable? err
-          err.instance_of?(Google::Cloud::UnavailableError) ||
-            err.instance_of?(GRPC::Unavailable) ||
-            (err.instance_of?(Google::Cloud::InternalError) && err.message.include?(EOS_INTERNAL_ERROR)) ||
-            (err.instance_of?(GRPC::Internal) && err.details.include?(EOS_INTERNAL_ERROR)) ||
-            (err.instance_of?(Google::Cloud::InternalError) && err.message.include?(RST_STREAM_INTERNAL_ERROR)) ||
-            (err.instance_of?(GRPC::Internal) && err.details.include?(RST_STREAM_INTERNAL_ERROR))
-        end
 
         ##
         # @private

--- a/google-cloud-spanner/lib/google/cloud/spanner/results.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/results.rb
@@ -225,7 +225,6 @@ module Google
           resume_token && !resume_token.empty?
         end
 
-
         ##
         # @private
         # Resumes a request, by re-executing it with a resume token.


### PR DESCRIPTION
- move retryable? method to service
- update results to use retryable? from service
- update transaction to rescue Internal errors and retry if it is for `RST_STREAM`