### PR TITLE
chore: Rename queue references to stacks

### DIFF
--- a/google-cloud-spanner/lib/google/cloud/spanner/pool.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/pool.rb
@@ -30,8 +30,8 @@ module Google
       #
       class Pool
         attr_accessor :all_sessions
-        attr_accessor :session_queue
-        attr_accessor :transaction_queue
+        attr_accessor :session_stack
+        attr_accessor :transaction_stack
 
         def initialize client, min: 10, max: 100, keepalive: 1800,
                        write_ratio: 0.3, fail: true, threads: nil
@@ -69,9 +69,9 @@ module Google
 
               # Use LIFO to ensure sessions are used from backend caches, which
               # will reduce the read / write latencies on user requests.
-              read_session = session_queue.pop # LIFO
+              read_session = session_stack.pop # LIFO
               return read_session if read_session
-              write_transaction = transaction_queue.pop # LIFO
+              write_transaction = transaction_stack.pop # LIFO
               return write_transaction.session if write_transaction
 
               if can_allocate_more_sessions?
@@ -94,7 +94,7 @@ module Google
               raise ArgumentError, "Cannot checkin session"
             end
 
-            session_queue.push session
+            session_stack.push session
 
             @resource.signal
           end
@@ -121,9 +121,9 @@ module Google
             loop do
               raise ClientClosedError if @closed
 
-              write_transaction = transaction_queue.pop # LIFO
+              write_transaction = transaction_stack.pop # LIFO
               return write_transaction if write_transaction
-              read_session = session_queue.pop
+              read_session = session_stack.pop
               if read_session
                 action = read_session
                 break
@@ -151,7 +151,7 @@ module Google
               raise ArgumentError, "Cannot checkin session"
             end
 
-            transaction_queue.push txn
+            transaction_stack.push txn
 
             @resource.signal
           end
@@ -182,11 +182,11 @@ module Google
           to_release = []
 
           @mutex.synchronize do
-            available_count = session_queue.count + transaction_queue.count
+            available_count = session_stack.count + transaction_stack.count
             release_count = @min - available_count
             release_count = 0 if release_count.negative?
 
-            to_keepalive += (session_queue + transaction_queue).select do |x|
+            to_keepalive += (session_stack + transaction_stack).select do |x|
               x.idle_since? @keepalive
             end
 
@@ -196,8 +196,8 @@ module Google
 
             # Remove those to be released from circulation
             @all_sessions -= to_release.map(&:session)
-            @session_queue -= to_release
-            @transaction_queue -= to_release
+            @session_stack -= to_release
+            @transaction_stack -= to_release
           end
 
           to_release.each { |x| future { x.release! } }
@@ -212,7 +212,7 @@ module Google
             max_threads: @threads
           # init the queues
           @new_sessions_in_process = 0
-          @transaction_queue = []
+          @transaction_stack = []
           # init the keepalive task
           create_keepalive_task!
           # init session queue
@@ -224,7 +224,7 @@ module Google
           pending_transactions.each do |transaction|
             future { checkin_transaction transaction.create_transaction }
           end
-          @session_queue = sessions
+          @session_stack = sessions
         end
 
         def shutdown
@@ -238,8 +238,8 @@ module Google
           @mutex.synchronize do
             @all_sessions.each { |s| future { s.release! } }
             @all_sessions = []
-            @session_queue = []
-            @transaction_queue = []
+            @session_stack = []
+            @transaction_stack = []
           end
           # shutdown existing thread pool
           @thread_pool.shutdown

--- a/google-cloud-spanner/lib/google/cloud/spanner/pool.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/pool.rb
@@ -48,7 +48,7 @@ module Google
           @mutex = Mutex.new
           @resource = ConditionVariable.new
 
-          # initialize pool and availability queue
+          # initialize pool and availability stack
           init
         end
 
@@ -210,17 +210,17 @@ module Google
           # init the thread pool
           @thread_pool = Concurrent::ThreadPoolExecutor.new \
             max_threads: @threads
-          # init the queues
+          # init the stacks
           @new_sessions_in_process = 0
           @transaction_stack = []
           # init the keepalive task
           create_keepalive_task!
-          # init session queue
+          # init session stack
           @all_sessions = @client.batch_create_new_sessions @min
           sessions = @all_sessions.dup
           num_transactions = (@min * @write_ratio).round
           pending_transactions = sessions.shift num_transactions
-          # init transaction queue
+          # init transaction stack
           pending_transactions.each do |transaction|
             future { checkin_transaction transaction.create_transaction }
           end

--- a/google-cloud-spanner/test/google/cloud/spanner/client/close_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/close_test.rb
@@ -31,7 +31,7 @@ describe Google::Cloud::Spanner::Client, :close, :mock_spanner do
     session.instance_variable_set :@last_updated_at, Time.now
     p = client.instance_variable_get :@pool
     p.all_sessions = [session]
-    p.session_queue = [session]
+    p.session_stack = [session]
   end
 
   it "deletes sessions when closed" do

--- a/google-cloud-spanner/test/google/cloud/spanner/pool/close_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/pool/close_test.rb
@@ -26,7 +26,7 @@ describe Google::Cloud::Spanner::Pool, :close, :mock_spanner do
     session.instance_variable_set :@last_updated_at, Time.now
     p = client.instance_variable_get :@pool
     p.all_sessions = [session]
-    p.session_queue = [session]
+    p.session_stack = [session]
     p
   end
 

--- a/google-cloud-spanner/test/google/cloud/spanner/pool/keepalive_or_release_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/pool/keepalive_or_release_test.rb
@@ -56,7 +56,7 @@ describe Google::Cloud::Spanner::Pool, :keepalive_or_release, :mock_spanner do
     session.instance_variable_set :@last_updated_at, Time.now - 60*60
     # set the session in the pool
     pool.all_sessions = [session]
-    pool.session_queue = [session]
+    pool.session_stack = [session]
 
     mock = Minitest::Mock.new
     session.service.mocked_service = mock
@@ -74,7 +74,7 @@ describe Google::Cloud::Spanner::Pool, :keepalive_or_release, :mock_spanner do
     session.instance_variable_set :@last_updated_at, Time.now - 60*60
     # set the session in the pool
     pool.all_sessions = [session]
-    pool.transaction_queue = [transaction]
+    pool.transaction_stack = [transaction]
 
     mock = Minitest::Mock.new
     mock.expect :begin_transaction, transaction_grpc, [{
@@ -94,7 +94,7 @@ describe Google::Cloud::Spanner::Pool, :keepalive_or_release, :mock_spanner do
     session.instance_variable_set :@last_updated_at, Time.now
     # set the session in the pool
     pool.all_sessions = [session]
-    pool.session_queue = [session]
+    pool.session_stack = [session]
 
     mock = Minitest::Mock.new
     session.service.mocked_service = mock
@@ -111,7 +111,7 @@ describe Google::Cloud::Spanner::Pool, :keepalive_or_release, :mock_spanner do
     session.instance_variable_set :@last_updated_at, Time.now
     # set the session in the pool
     pool.all_sessions = [session]
-    pool.transaction_queue = [transaction]
+    pool.transaction_stack = [transaction]
 
     mock = Minitest::Mock.new
     session.service.mocked_service = mock

--- a/google-cloud-spanner/test/google/cloud/spanner/pool/new_sessions_in_process_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/pool/new_sessions_in_process_test.rb
@@ -47,7 +47,7 @@ describe Google::Cloud::Spanner::Pool, :new_sessions_in_process, :mock_spanner d
     _(pool.session_stack.size).must_equal 1
     _(pool.instance_variable_get(:@new_sessions_in_process)).must_equal 0
 
-    s1 = pool.checkout_session # gets the one session from the queue
+    s1 = pool.checkout_session # gets the one session from the stack
 
     _(pool.all_sessions.size).must_equal 1
     _(pool.session_stack.size).must_equal 0

--- a/google-cloud-spanner/test/google/cloud/spanner/pool/new_sessions_in_process_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/pool/new_sessions_in_process_test.rb
@@ -27,8 +27,8 @@ describe Google::Cloud::Spanner::Pool, :new_sessions_in_process, :mock_spanner d
     session.instance_variable_set :@last_updated_at, Time.now
     p = client.instance_variable_get :@pool
     p.all_sessions = [session]
-    p.session_queue = [session]
-    p.transaction_queue = []
+    p.session_stack = [session]
+    p.transaction_stack = []
     p
   end
 
@@ -44,13 +44,13 @@ describe Google::Cloud::Spanner::Pool, :new_sessions_in_process, :mock_spanner d
     spanner.service.mocked_service = stub
 
     _(pool.all_sessions.size).must_equal 1
-    _(pool.session_queue.size).must_equal 1
+    _(pool.session_stack.size).must_equal 1
     _(pool.instance_variable_get(:@new_sessions_in_process)).must_equal 0
 
     s1 = pool.checkout_session # gets the one session from the queue
 
     _(pool.all_sessions.size).must_equal 1
-    _(pool.session_queue.size).must_equal 0
+    _(pool.session_stack.size).must_equal 0
     _(pool.instance_variable_get(:@new_sessions_in_process)).must_equal 0
 
     raised_error = assert_raises Google::Cloud::Error do
@@ -59,7 +59,7 @@ describe Google::Cloud::Spanner::Pool, :new_sessions_in_process, :mock_spanner d
     _(raised_error.message).must_equal "11:sumthin happen"
 
     _(pool.all_sessions.size).must_equal 1
-    _(pool.session_queue.size).must_equal 0
+    _(pool.session_stack.size).must_equal 0
     _(pool.instance_variable_get(:@new_sessions_in_process)).must_equal 0
 
     10.times do
@@ -70,7 +70,7 @@ describe Google::Cloud::Spanner::Pool, :new_sessions_in_process, :mock_spanner d
     end
 
     _(pool.all_sessions.size).must_equal 1
-    _(pool.session_queue.size).must_equal 0
+    _(pool.session_stack.size).must_equal 0
     _(pool.instance_variable_get(:@new_sessions_in_process)).must_equal 0
 
     pool.checkin_session s1
@@ -78,7 +78,7 @@ describe Google::Cloud::Spanner::Pool, :new_sessions_in_process, :mock_spanner d
     shutdown_pool! pool
 
     _(pool.all_sessions.size).must_equal 1
-    _(pool.session_queue.size).must_equal 1
+    _(pool.session_stack.size).must_equal 1
     _(pool.instance_variable_get(:@new_sessions_in_process)).must_equal 0
   end
 end

--- a/google-cloud-spanner/test/google/cloud/spanner/pool/write_ratio_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/pool/write_ratio_test.rb
@@ -24,7 +24,7 @@ describe Google::Cloud::Spanner::Pool, :write_ratio, :mock_spanner do
     session.instance_variable_set :@last_updated_at, Time.now
     p = client.instance_variable_get :@pool
     p.all_sessions = [session]
-    p.session_queue = [session]
+    p.session_stack = [session]
     p
   end
 
@@ -49,8 +49,8 @@ describe Google::Cloud::Spanner::Pool, :write_ratio, :mock_spanner do
     shutdown_pool! pool
 
     _(pool.all_sessions.size).must_equal 2
-    _(pool.session_queue.size).must_equal 1
-    _(pool.transaction_queue.size).must_equal 1
+    _(pool.session_stack.size).must_equal 1
+    _(pool.transaction_stack.size).must_equal 1
 
     mock.verify
   end
@@ -77,8 +77,8 @@ describe Google::Cloud::Spanner::Pool, :write_ratio, :mock_spanner do
     shutdown_pool! pool
 
     _(pool.all_sessions.size).must_equal 2
-    _(pool.session_queue.size).must_equal 1
-    _(pool.transaction_queue.size).must_equal 1
+    _(pool.session_stack.size).must_equal 1
+    _(pool.transaction_stack.size).must_equal 1
 
     mock.verify
   end
@@ -105,8 +105,8 @@ describe Google::Cloud::Spanner::Pool, :write_ratio, :mock_spanner do
     shutdown_pool! pool
 
     _(pool.all_sessions.size).must_equal 5
-    _(pool.session_queue.size).must_equal 2
-    _(pool.transaction_queue.size).must_equal 3
+    _(pool.session_stack.size).must_equal 2
+    _(pool.transaction_stack.size).must_equal 3
 
     mock.verify
   end
@@ -135,8 +135,8 @@ describe Google::Cloud::Spanner::Pool, :write_ratio, :mock_spanner do
     shutdown_pool! pool
 
     _(pool.all_sessions.size).must_equal 8
-    _(pool.session_queue.size).must_equal 6
-    _(pool.transaction_queue.size).must_equal 2
+    _(pool.session_stack.size).must_equal 6
+    _(pool.transaction_stack.size).must_equal 2
 
     mock.verify
   end


### PR DESCRIPTION
This is a small refactoring PR as part of the "Inline Begin Transaction" that I'm working on.

The `Pool` class internally maintains stacks to process available sessions & transactions, but refers to them as queues. These fields are processed with LIFO behaviour (as mentioned in comments), so they should be called stacks.

No breaking changes, since `Pool` class isn't exposed to users.