### PR TITLE
fix(spanner): Use hash to track the sessions in use

### DIFF
--- a/google-cloud-spanner/test/google/cloud/spanner/client/close_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/close_test.rb
@@ -31,7 +31,7 @@ describe Google::Cloud::Spanner::Client, :close, :mock_spanner do
     session.instance_variable_set :@last_updated_at, Time.now
     p = client.instance_variable_get :@pool
     p.sessions_available = [session]
-    p.sessions_in_use = []
+    p.sessions_in_use = {}
   end
 
   it "deletes sessions when closed" do

--- a/google-cloud-spanner/test/google/cloud/spanner/pool/batch_create_sessions_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/pool/batch_create_sessions_test.rb
@@ -20,13 +20,6 @@ describe Google::Cloud::Spanner::Pool, :batch_create_sessions, :mock_spanner do
   let(:client) { spanner.client instance_id, database_id, pool: { min: 0, max: 4 } }
   let(:tx_opts) { Google::Cloud::Spanner::V1::TransactionOptions.new(read_write: Google::Cloud::Spanner::V1::TransactionOptions::ReadWrite.new) }
   let(:default_options) { ::Gapic::CallOptions.new metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
-  let(:client_pool) do
-    session.instance_variable_set :@last_updated_at, Time.now
-    p = client.instance_variable_get :@pool
-    p.sessions_available = [session]
-    p.sessions_in_use = []
-    p
-  end
 
   after do
     shutdown_client! client

--- a/google-cloud-spanner/test/google/cloud/spanner/pool/close_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/pool/close_test.rb
@@ -26,7 +26,7 @@ describe Google::Cloud::Spanner::Pool, :close, :mock_spanner do
     session.instance_variable_set :@last_updated_at, Time.now
     p = client.instance_variable_get :@pool
     p.sessions_available = [session]
-    p.sessions_in_use = []
+    p.sessions_in_use = {}
     p
   end
 

--- a/google-cloud-spanner/test/google/cloud/spanner/pool/keepalive_or_release_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/pool/keepalive_or_release_test.rb
@@ -56,7 +56,7 @@ describe Google::Cloud::Spanner::Pool, :keepalive_or_release, :mock_spanner do
     session.instance_variable_set :@last_updated_at, Time.now - 60*60
     # set the session in the pool
     pool.sessions_available = [session]
-    pool.sessions_in_use = []
+    pool.sessions_in_use = {}
 
     mock = Minitest::Mock.new
     session.service.mocked_service = mock
@@ -74,7 +74,7 @@ describe Google::Cloud::Spanner::Pool, :keepalive_or_release, :mock_spanner do
     session.instance_variable_set :@last_updated_at, Time.now
     # set the session in the pool
     pool.sessions_available = [session]
-    pool.sessions_in_use = []
+    pool.sessions_in_use = {}
 
     mock = Minitest::Mock.new
     session.service.mocked_service = mock

--- a/google-cloud-spanner/test/google/cloud/spanner/pool/new_sessions_in_process_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/pool/new_sessions_in_process_test.rb
@@ -27,7 +27,7 @@ describe Google::Cloud::Spanner::Pool, :new_sessions_in_process, :mock_spanner d
     session.instance_variable_set :@last_updated_at, Time.now
     p = client.instance_variable_get :@pool
     p.sessions_available = [session]
-    p.sessions_in_use = []
+    p.sessions_in_use = {}
     p
   end
 

--- a/google-cloud-spanner/test/google/cloud/spanner/pool_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/pool_test.rb
@@ -32,7 +32,7 @@ describe Google::Cloud::Spanner::Pool, :mock_spanner do
     session.instance_variable_set :@last_updated_at, Time.now
     p = client.instance_variable_get :@pool
     p.sessions_available = [session]
-    p.sessions_in_use = []
+    p.sessions_in_use = {}
     p
   end
 

--- a/google-cloud-spanner/test/helper.rb
+++ b/google-cloud-spanner/test/helper.rb
@@ -39,7 +39,7 @@ class MockSpanner < Minitest::Spec
     pool = client.instance_variable_get :@pool
     # remove all sessions so we don't have to handle the calls to session_delete
     pool.sessions_available = []
-    pool.sessions_in_use = []
+    pool.sessions_in_use = {}
 
     # close the client
     client.close


### PR DESCRIPTION
This is a minor follow-up optimization to the "Inline Begin Transaction" recently implemented in #54.

The `Pool#sessions_in_use` field is presently an `array` of session objects. But a `hash` data structure suits it better for its use-cases (1. add session, 2. look-up if a session is previously added, 3. remove a session), with no necessity of ordering.

This optimization will primarily benefit the `checkin` and `checkout` operations for the session pool, since the existing code scans the full array for every checkin/checkout operation.

I changed the test data accordingly, and removed an obsolete fixture.