### PR TITLE
chore(spanner): Simplify batch_update() code

### DIFF
--- a/google-cloud-spanner/lib/google/cloud/spanner/transaction.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/transaction.rb
@@ -640,20 +640,12 @@ module Google
 
           request_options = build_request_options request_options
           safe_execute do |seqno|
-            batch_update_results = nil
-            begin
-              response = session.batch_update tx_selector, seqno,
-                                              request_options: request_options,
-                                              call_options: call_options, &block
-              batch_update_results = BatchUpdateResults.new response
-              row_counts = batch_update_results.row_counts
-              @grpc ||= batch_update_results.transaction
-              return row_counts
-            rescue Google::Cloud::Spanner::BatchUpdateError
-              @grpc ||= batch_update_results.transaction
-              # Re-raise after extracting transaction
-              raise
-            end
+            response = session.batch_update tx_selector, seqno,
+                                            request_options: request_options,
+                                            call_options: call_options, &block
+            batch_update_results = BatchUpdateResults.new response
+            @grpc ||= batch_update_results.transaction
+            batch_update_results.row_counts
           end
         end
 

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/batch_update_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/batch_update_test.rb
@@ -191,7 +191,7 @@ describe Google::Cloud::Spanner::Transaction, :batch_update, :mock_spanner do
     end
   end
 
-  it "can execute a barch DML with transaction and request tag" do
+  it "can execute a batch DML with transaction and request tag" do
     transaction = Google::Cloud::Spanner::Transaction.from_grpc nil, session
     transaction.transaction_tag = "Tag-1"
 


### PR DESCRIPTION
Minor refactor to simplify the flow of `tx.batch_update()`. Follow-up of Inline Begin Transaction implemented in #54.

By extracting the transaction _before_ processing the `row_counts`, we can avoid having an explicit `rescue` block and reduce the nesting.