### PR TITLE
fix: Bump up minimum version of google-cloud-spanner-v1 to 0.19.0

### DIFF
--- a/google-cloud-spanner/Gemfile
+++ b/google-cloud-spanner/Gemfile
@@ -6,6 +6,6 @@ gem "google-cloud-core", "~> 1.6.0"
 gem "google-cloud-errors", "~> 1.3.0"
 gem "google-cloud-spanner-admin-database-v1", ">= 0.11.0"
 gem "google-cloud-spanner-admin-instance-v1", ">= 0.7.0"
-gem "google-cloud-spanner-v1", ">= 0.10.0"
+gem "google-cloud-spanner-v1", ">= 0.19.0"
 
 gem "rake"


### PR DESCRIPTION
The handwritten client supports Directed Read Options, so the dependency version of `google-cloud-spanner-v1` has to be at least 0.19.0.

Unit tests were failing on my local system because of this.