### PR TITLE
feat(Spanner): support  max_commit_delay for commit_options

### DIFF
--- a/google-cloud-spanner/acceptance/spanner/client/crud_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/crud_test.rb
@@ -135,11 +135,10 @@ describe "Spanner Client", :crud, :spanner do
       _(results.timestamp).wont_be :nil?
     end
 
-    focus
     it "commits with max commit delay for #{dialect}" do
       skip if emulator_enabled?
 
-      commit_options = { return_commit_stats: true, max_commit_delay: 0.1 }
+      commit_options = { return_commit_stats: true, max_commit_delay: 120 }
       commit_resp = db[dialect].commit commit_options: commit_options do |c|
         c.insert "accounts", @default_rows[dialect][0]
       end

--- a/google-cloud-spanner/acceptance/spanner/client/crud_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/crud_test.rb
@@ -104,6 +104,7 @@ describe "Spanner Client", :crud, :spanner do
       _(results.timestamp).wont_be :nil?
     end
 
+    focus
     it "inserts, updates, upserts, reads, and deletes records using commit and return commit stats for #{dialect}" do
       skip if emulator_enabled?
 

--- a/google-cloud-spanner/lib/google/cloud/spanner/client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/client.rb
@@ -1025,7 +1025,7 @@ module Google
         #   *  `:maxCommitDelay` (Numeric) The amount of latency in millisecond in this request
         #         is willing to incur in order to improve throughput.
         #         The commit delay must be at least 0ms and at most 500ms
-        #         Default value is nil. 
+        #         Default value is nil.
         # @param [Hash] request_options Common request options.
         #
         #   * `:priority` (String) The relative priority for requests.
@@ -1148,7 +1148,7 @@ module Google
         #   *  `:maxCommitDelay` (Numeric) The amount of latency in millisecond in this request
         #         is willing to incur in order to improve throughput.
         #         The commit delay must be at least 0ms and at most 500ms
-        #         Default value is nil. 
+        #         Default value is nil.
         # @param [Hash] request_options Common request options.
         #
         #   * `:priority` (String) The relative priority for requests.
@@ -1270,7 +1270,7 @@ module Google
         #   *  `:maxCommitDelay` (Numeric) The amount of latency in millisecond in this request
         #         is willing to incur in order to improve throughput.
         #         The commit delay must be at least 0ms and at most 500ms
-        #         Default value is nil. 
+        #         Default value is nil.
         # @param [Hash] request_options Common request options.
         #
         #   * `:priority` (String) The relative priority for requests.
@@ -1393,7 +1393,7 @@ module Google
         #   *  `:maxCommitDelay` (Numeric) The amount of latency in millisecond in this request
         #         is willing to incur in order to improve throughput.
         #         The commit delay must be at least 0ms and at most 500ms
-        #         Default value is nil. 
+        #         Default value is nil.
         # @param [Hash] request_options Common request options.
         #
         #   * `:priority` (String) The relative priority for requests.
@@ -1494,7 +1494,7 @@ module Google
         #   *  `:maxCommitDelay` (Numeric) The amount of latency in millisecond in this request
         #         is willing to incur in order to improve throughput.
         #         The commit delay must be at least 0ms and at most 500ms
-        #         Default value is nil. 
+        #         Default value is nil.
         # @param [Hash] request_options Common request options.
         #
         #   * `:priority` (String) The relative priority for requests.
@@ -1602,7 +1602,7 @@ module Google
         #   *  `:maxCommitDelay` (Numeric) The amount of latency in millisecond in this request
         #         is willing to incur in order to improve throughput.
         #         The commit delay must be at least 0ms and at most 500ms
-        #         Default value is nil. 
+        #         Default value is nil.
         # @param [Hash] request_options Common request options.
         #
         #   * `:priority` (String) The relative priority for requests.
@@ -1733,7 +1733,7 @@ module Google
         #   *  `:maxCommitDelay` (Numeric) The amount of latency in millisecond in this request
         #         is willing to incur in order to improve throughput.
         #         The commit delay must be at least 0ms and at most 500ms
-        #         Default value is nil. 
+        #         Default value is nil.
         # @param [Hash] request_options Common request options.
         #
         #   * `:priority` (String) The relative priority for requests.

--- a/google-cloud-spanner/lib/google/cloud/spanner/client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/client.rb
@@ -1024,7 +1024,7 @@ module Google
         #     {CommitResponse}. Default value is `false`
         #   *  `:maxCommitDelay` (Numeric) The amount of latency in millisecond in this request
         #         is willing to incur in order to improve throughput.
-        #         The commit delay must be at least 0ms and at most 500ms
+        #         The commit delay must be at least 0ms and at most 500ms.
         #         Default value is nil.
         # @param [Hash] request_options Common request options.
         #
@@ -1147,7 +1147,7 @@ module Google
         #     {CommitResponse}. Default value is `false`
         #   *  `:maxCommitDelay` (Numeric) The amount of latency in millisecond in this request
         #         is willing to incur in order to improve throughput.
-        #         The commit delay must be at least 0ms and at most 500ms
+        #         The commit delay must be at least 0ms and at most 500ms.
         #         Default value is nil.
         # @param [Hash] request_options Common request options.
         #
@@ -1269,7 +1269,7 @@ module Google
         #     {CommitResponse}. Default value is `false`
         #   *  `:maxCommitDelay` (Numeric) The amount of latency in millisecond in this request
         #         is willing to incur in order to improve throughput.
-        #         The commit delay must be at least 0ms and at most 500ms
+        #         The commit delay must be at least 0ms and at most 500ms.
         #         Default value is nil.
         # @param [Hash] request_options Common request options.
         #
@@ -1392,7 +1392,7 @@ module Google
         #     {CommitResponse}. Default value is `false`
         #   *  `:maxCommitDelay` (Numeric) The amount of latency in millisecond in this request
         #         is willing to incur in order to improve throughput.
-        #         The commit delay must be at least 0ms and at most 500ms
+        #         The commit delay must be at least 0ms and at most 500ms.
         #         Default value is nil.
         # @param [Hash] request_options Common request options.
         #
@@ -1493,7 +1493,7 @@ module Google
         #     {CommitResponse}. Default value is `false`
         #   *  `:maxCommitDelay` (Numeric) The amount of latency in millisecond in this request
         #         is willing to incur in order to improve throughput.
-        #         The commit delay must be at least 0ms and at most 500ms
+        #         The commit delay must be at least 0ms and at most 500ms.
         #         Default value is nil.
         # @param [Hash] request_options Common request options.
         #
@@ -1601,7 +1601,7 @@ module Google
         #     {CommitResponse}. Default value is `false`
         #   *  `:maxCommitDelay` (Numeric) The amount of latency in millisecond in this request
         #         is willing to incur in order to improve throughput.
-        #         The commit delay must be at least 0ms and at most 500ms
+        #         The commit delay must be at least 0ms and at most 500ms.
         #         Default value is nil.
         # @param [Hash] request_options Common request options.
         #
@@ -1732,7 +1732,7 @@ module Google
         #     {CommitResponse}. Default value is `false`
         #   *  `:maxCommitDelay` (Numeric) The amount of latency in millisecond in this request
         #         is willing to incur in order to improve throughput.
-        #         The commit delay must be at least 0ms and at most 500ms
+        #         The commit delay must be at least 0ms and at most 500ms.
         #         Default value is nil.
         # @param [Hash] request_options Common request options.
         #

--- a/google-cloud-spanner/lib/google/cloud/spanner/client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/client.rb
@@ -1022,6 +1022,10 @@ module Google
         #   * `:return_commit_stats` (Boolean) A boolean value. If `true`,
         #     then statistics related to the transaction will be included in
         #     {CommitResponse}. Default value is `false`
+        #   *  `:maxCommitDelay` (Numeric) The amount of latency in millisecond in this request
+        #         is willing to incur in order to improve throughput.
+        #         The commit delay must be at least 0ms and at most 500ms
+        #         Default value is nil. 
         # @param [Hash] request_options Common request options.
         #
         #   * `:priority` (String) The relative priority for requests.
@@ -1141,6 +1145,10 @@ module Google
         #   * `:return_commit_stats` (Boolean) A boolean value. If `true`,
         #     then statistics related to the transaction will be included in
         #     {CommitResponse}. Default value is `false`
+        #   *  `:maxCommitDelay` (Numeric) The amount of latency in millisecond in this request
+        #         is willing to incur in order to improve throughput.
+        #         The commit delay must be at least 0ms and at most 500ms
+        #         Default value is nil. 
         # @param [Hash] request_options Common request options.
         #
         #   * `:priority` (String) The relative priority for requests.
@@ -1259,6 +1267,10 @@ module Google
         #   * `:return_commit_stats` (Boolean) A boolean value. If `true`,
         #     then statistics related to the transaction will be included in
         #     {CommitResponse}. Default value is `false`
+        #   *  `:maxCommitDelay` (Numeric) The amount of latency in millisecond in this request
+        #         is willing to incur in order to improve throughput.
+        #         The commit delay must be at least 0ms and at most 500ms
+        #         Default value is nil. 
         # @param [Hash] request_options Common request options.
         #
         #   * `:priority` (String) The relative priority for requests.
@@ -1378,6 +1390,10 @@ module Google
         #   * `:return_commit_stats` (Boolean) A boolean value. If `true`,
         #     then statistics related to the transaction will be included in
         #     {CommitResponse}. Default value is `false`
+        #   *  `:maxCommitDelay` (Numeric) The amount of latency in millisecond in this request
+        #         is willing to incur in order to improve throughput.
+        #         The commit delay must be at least 0ms and at most 500ms
+        #         Default value is nil. 
         # @param [Hash] request_options Common request options.
         #
         #   * `:priority` (String) The relative priority for requests.
@@ -1475,6 +1491,10 @@ module Google
         #   * `:return_commit_stats` (Boolean) A boolean value. If `true`,
         #     then statistics related to the transaction will be included in
         #     {CommitResponse}. Default value is `false`
+        #   *  `:maxCommitDelay` (Numeric) The amount of latency in millisecond in this request
+        #         is willing to incur in order to improve throughput.
+        #         The commit delay must be at least 0ms and at most 500ms
+        #         Default value is nil. 
         # @param [Hash] request_options Common request options.
         #
         #   * `:priority` (String) The relative priority for requests.
@@ -1579,6 +1599,10 @@ module Google
         #   * `:return_commit_stats` (Boolean) A boolean value. If `true`,
         #     then statistics related to the transaction will be included in
         #     {CommitResponse}. Default value is `false`
+        #   *  `:maxCommitDelay` (Numeric) The amount of latency in millisecond in this request
+        #         is willing to incur in order to improve throughput.
+        #         The commit delay must be at least 0ms and at most 500ms
+        #         Default value is nil. 
         # @param [Hash] request_options Common request options.
         #
         #   * `:priority` (String) The relative priority for requests.
@@ -1706,6 +1730,10 @@ module Google
         #   * `:return_commit_stats` (Boolean) A boolean value. If `true`,
         #     then statistics related to the transaction will be included in
         #     {CommitResponse}. Default value is `false`
+        #   *  `:maxCommitDelay` (Numeric) The amount of latency in millisecond in this request
+        #         is willing to incur in order to improve throughput.
+        #         The commit delay must be at least 0ms and at most 500ms
+        #         Default value is nil. 
         # @param [Hash] request_options Common request options.
         #
         #   * `:priority` (String) The relative priority for requests.

--- a/google-cloud-spanner/lib/google/cloud/spanner/convert.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/convert.rb
@@ -242,8 +242,9 @@ module Google
             Hash[row_to_pairs(row_types, row)]
           end
 
-          def number_to_duration number
+          def number_to_duration number, millisecond: false
             return nil if number.nil?
+            number = number/1000.to_f if millisecond
 
             Google::Protobuf::Duration.new \
               seconds: number.to_i,

--- a/google-cloud-spanner/lib/google/cloud/spanner/service.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/service.rb
@@ -461,7 +461,7 @@ module Google
         def add_commit_options request, commit_options
           if commit_options
             request[:return_commit_stats] = commit_options[:return_commit_stats] if commit_options.key?(:return_commit_stats)
-            request[:max_commit_delay] = Convert.number_to_duration(commit_options[:max_commit_delay]) if commit_options.key?(:max_commit_delay)
+            request[:max_commit_delay] = Convert.number_to_duration(commit_options[:max_commit_delay], millisecond: true) if commit_options.key?(:max_commit_delay)
           end
           request
         end

--- a/google-cloud-spanner/lib/google/cloud/spanner/service.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/service.rb
@@ -455,6 +455,7 @@ module Google
 
           if commit_options
             request[:return_commit_stats] = commit_options[:return_commit_stats]
+            request[:max_commit_delay] = nil
           end
 
           service.commit request, opts

--- a/google-cloud-spanner/lib/google/cloud/spanner/service.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/service.rb
@@ -453,12 +453,17 @@ module Google
             request_options: request_options
           }
 
-          if commit_options
-            request[:return_commit_stats] = commit_options[:return_commit_stats]
-            request[:max_commit_delay] = nil
-          end
+          request = add_commit_options request, commit_options
 
           service.commit request, opts
+        end
+
+        def add_commit_options request, commit_options
+          if commit_options
+            request[:return_commit_stats] = commit_options[:return_commit_stats] if commit_options.key?(:return_commit_stats)
+            request[:max_commit_delay] = Convert.number_to_duration(commit_options[:max_commit_delay]) if commit_options.key?(:max_commit_delay)
+          end
+          request
         end
 
         def rollback session_name, transaction_id, call_options: nil

--- a/google-cloud-spanner/lib/google/cloud/spanner/service.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/service.rb
@@ -460,8 +460,15 @@ module Google
 
         def add_commit_options request, commit_options
           if commit_options
-            request[:return_commit_stats] = commit_options[:return_commit_stats] if commit_options.key?(:return_commit_stats)
-            request[:max_commit_delay] = Convert.number_to_duration(commit_options[:max_commit_delay], millisecond: true) if commit_options.key?(:max_commit_delay)
+            if commit_options.key? :return_commit_stats
+              request[:return_commit_stats] =
+                commit_options[:return_commit_stats]
+            end
+            if commit_options.key? :max_commit_delay
+              request[:max_commit_delay] =
+                Convert.number_to_duration(commit_options[:max_commit_delay],
+                                           millisecond: true)
+            end
           end
           request
         end

--- a/google-cloud-spanner/lib/google/cloud/spanner/session.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/session.rb
@@ -569,8 +569,11 @@ module Google
         #   * `:return_commit_stats` (Boolean) A boolean value. If `true`,
         #     then statistics related to the transaction will be included in
         #     {CommitResponse}. Default value is `false`
+        #   *  `:maxCommitDelay` (Numeric) The amount of latency in millisecond in this request
+        #         is willing to incur in order to improve throughput.
+        #         The commit delay must be at least 0ms and at most 500ms
+        #         Default value is nil. 
         #
-        # transaction. Default it is `false`.
         # @param [Hash] request_options Common request options.
         #
         #   * `:request_tag` (String) A per-request tag which can be applied
@@ -686,7 +689,10 @@ module Google
         #   * `:return_commit_stats` (Boolean) A boolean value. If `true`,
         #     then statistics related to the transaction will be included in
         #     {CommitResponse}. Default value is `false`
-        #
+        #   *  `:maxCommitDelay` (Numeric) The amount of latency in millisecond in this request
+        #         is willing to incur in order to improve throughput.
+        #         The commit delay must be at least 0ms and at most 500ms
+        #         Default value is nil. 
         # @param [Hash] request_options Common request options.
         #
         #   * `:request_tag` (String) A per-request tag which can be applied
@@ -794,7 +800,10 @@ module Google
         #   * `:return_commit_stats` (Boolean) A boolean value. If `true`,
         #     then statistics related to the transaction will be included in
         #     {CommitResponse}. Default value is `false`
-        #
+        #   *  `:maxCommitDelay` (Numeric) The amount of latency in millisecond in this request
+        #         is willing to incur in order to improve throughput.
+        #         The commit delay must be at least 0ms and at most 500ms
+        #         Default value is nil. 
         # @param [Hash] request_options Common request options.
         #
         #   * `:request_tag` (String) A per-request tag which can be applied
@@ -901,7 +910,10 @@ module Google
         #   * `:return_commit_stats` (Boolean) A boolean value. If `true`,
         #     then statistics related to the transaction will be included in
         #     {CommitResponse}. Default value is `false`
-        #
+        #   *  `:maxCommitDelay` (Numeric) The amount of latency in millisecond in this request
+        #         is willing to incur in order to improve throughput.
+        #         The commit delay must be at least 0ms and at most 500ms
+        #         Default value is nil. 
         # @param [Hash] request_options Common request options.
         #
         #   * `:request_tag` (String) A per-request tag which can be applied
@@ -1009,7 +1021,11 @@ module Google
         #
         #   * `:return_commit_stats` (Boolean) A boolean value. If `true`,
         #     then statistics related to the transaction will be included in
-        #     {CommitResponse}. Default value is `false`.
+        #     {CommitResponse}. Default value is `false`
+        #   *  `:maxCommitDelay` (Numeric) The amount of latency in millisecond in this request
+        #         is willing to incur in order to improve throughput.
+        #         The commit delay must be at least 0ms and at most 500ms
+        #         Default value is nil. 
         #
         # @param [Hash] request_options Common request options.
         #
@@ -1099,7 +1115,10 @@ module Google
         #   * `:return_commit_stats` (Boolean) A boolean value. If `true`,
         #     then statistics related to the transaction will be included in
         #     {CommitResponse}. Default value is `false`
-        #
+        #   *  `:maxCommitDelay` (Numeric) The amount of latency in millisecond in this request
+        #         is willing to incur in order to improve throughput.
+        #         The commit delay must be at least 0ms and at most 500ms
+        #         Default value is nil. 
         # @param [Hash] request_options Common request options.
         #
         #   * `:request_tag` (String) A per-request tag which can be applied

--- a/google-cloud-spanner/lib/google/cloud/spanner/session.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/session.rb
@@ -572,7 +572,7 @@ module Google
         #   *  `:maxCommitDelay` (Numeric) The amount of latency in millisecond in this request
         #         is willing to incur in order to improve throughput.
         #         The commit delay must be at least 0ms and at most 500ms
-        #         Default value is nil. 
+        #         Default value is nil.
         #
         # @param [Hash] request_options Common request options.
         #
@@ -692,7 +692,7 @@ module Google
         #   *  `:maxCommitDelay` (Numeric) The amount of latency in millisecond in this request
         #         is willing to incur in order to improve throughput.
         #         The commit delay must be at least 0ms and at most 500ms
-        #         Default value is nil. 
+        #         Default value is nil.
         # @param [Hash] request_options Common request options.
         #
         #   * `:request_tag` (String) A per-request tag which can be applied
@@ -803,7 +803,7 @@ module Google
         #   *  `:maxCommitDelay` (Numeric) The amount of latency in millisecond in this request
         #         is willing to incur in order to improve throughput.
         #         The commit delay must be at least 0ms and at most 500ms
-        #         Default value is nil. 
+        #         Default value is nil.
         # @param [Hash] request_options Common request options.
         #
         #   * `:request_tag` (String) A per-request tag which can be applied
@@ -913,7 +913,7 @@ module Google
         #   *  `:maxCommitDelay` (Numeric) The amount of latency in millisecond in this request
         #         is willing to incur in order to improve throughput.
         #         The commit delay must be at least 0ms and at most 500ms
-        #         Default value is nil. 
+        #         Default value is nil.
         # @param [Hash] request_options Common request options.
         #
         #   * `:request_tag` (String) A per-request tag which can be applied
@@ -1025,7 +1025,7 @@ module Google
         #   *  `:maxCommitDelay` (Numeric) The amount of latency in millisecond in this request
         #         is willing to incur in order to improve throughput.
         #         The commit delay must be at least 0ms and at most 500ms
-        #         Default value is nil. 
+        #         Default value is nil.
         #
         # @param [Hash] request_options Common request options.
         #
@@ -1118,7 +1118,7 @@ module Google
         #   *  `:maxCommitDelay` (Numeric) The amount of latency in millisecond in this request
         #         is willing to incur in order to improve throughput.
         #         The commit delay must be at least 0ms and at most 500ms
-        #         Default value is nil. 
+        #         Default value is nil.
         # @param [Hash] request_options Common request options.
         #
         #   * `:request_tag` (String) A per-request tag which can be applied

--- a/google-cloud-spanner/lib/google/cloud/spanner/session.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/session.rb
@@ -571,7 +571,7 @@ module Google
         #     {CommitResponse}. Default value is `false`
         #   *  `:maxCommitDelay` (Numeric) The amount of latency in millisecond in this request
         #         is willing to incur in order to improve throughput.
-        #         The commit delay must be at least 0ms and at most 500ms
+        #         The commit delay must be at least 0ms and at most 500ms.
         #         Default value is nil.
         #
         # @param [Hash] request_options Common request options.
@@ -691,7 +691,7 @@ module Google
         #     {CommitResponse}. Default value is `false`
         #   *  `:maxCommitDelay` (Numeric) The amount of latency in millisecond in this request
         #         is willing to incur in order to improve throughput.
-        #         The commit delay must be at least 0ms and at most 500ms
+        #         The commit delay must be at least 0ms and at most 500ms.
         #         Default value is nil.
         # @param [Hash] request_options Common request options.
         #
@@ -802,7 +802,7 @@ module Google
         #     {CommitResponse}. Default value is `false`
         #   *  `:maxCommitDelay` (Numeric) The amount of latency in millisecond in this request
         #         is willing to incur in order to improve throughput.
-        #         The commit delay must be at least 0ms and at most 500ms
+        #         The commit delay must be at least 0ms and at most 500ms.
         #         Default value is nil.
         # @param [Hash] request_options Common request options.
         #
@@ -912,7 +912,7 @@ module Google
         #     {CommitResponse}. Default value is `false`
         #   *  `:maxCommitDelay` (Numeric) The amount of latency in millisecond in this request
         #         is willing to incur in order to improve throughput.
-        #         The commit delay must be at least 0ms and at most 500ms
+        #         The commit delay must be at least 0ms and at most 500ms.
         #         Default value is nil.
         # @param [Hash] request_options Common request options.
         #
@@ -1024,7 +1024,7 @@ module Google
         #     {CommitResponse}. Default value is `false`
         #   *  `:maxCommitDelay` (Numeric) The amount of latency in millisecond in this request
         #         is willing to incur in order to improve throughput.
-        #         The commit delay must be at least 0ms and at most 500ms
+        #         The commit delay must be at least 0ms and at most 500ms.
         #         Default value is nil.
         #
         # @param [Hash] request_options Common request options.
@@ -1117,7 +1117,7 @@ module Google
         #     {CommitResponse}. Default value is `false`
         #   *  `:maxCommitDelay` (Numeric) The amount of latency in millisecond in this request
         #         is willing to incur in order to improve throughput.
-        #         The commit delay must be at least 0ms and at most 500ms
+        #         The commit delay must be at least 0ms and at most 500ms.
         #         Default value is nil.
         # @param [Hash] request_options Common request options.
         #

--- a/google-cloud-spanner/test/google/cloud/spanner/client/commit_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/commit_test.rb
@@ -572,9 +572,10 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
         )
       )]
       commit_options[:max_commit_delay] = 120
+      commit_delay_duration = Google::Cloud::Spanner::Convert.number_to_duration(120, millisecond: true)
       mock = Minitest::Mock.new
       mock.expect :create_session, session_grpc, [{database: database_path(instance_id, database_id), session: nil}, default_options]
-      mock.expect :commit, commit_stats_resp_grpc, [{ session: session_grpc.name, mutations: mutations, transaction_id: nil, single_use_transaction: tx_opts, return_commit_stats: true, max_commit_delay: Google::Cloud::Spanner::Convert.number_to_duration(120, millisecond: true), request_options: nil}, default_options]
+      mock.expect :commit, commit_stats_resp_grpc, [{ session: session_grpc.name, mutations: mutations, transaction_id: nil, single_use_transaction: tx_opts, return_commit_stats: true, max_commit_delay: commit_delay_duration, request_options: nil}, default_options]
       spanner.service.mocked_service = mock
 
       commit_resp = client.commit commit_options: commit_options do |c|

--- a/google-cloud-spanner/test/google/cloud/spanner/client/commit_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/commit_test.rb
@@ -428,7 +428,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
   end
 
   describe "commit options" do
-    let(:commit_options) { { return_commit_stats: true } }
+    let(:commit_options) { { return_commit_stats: true, max_commit_delay: nil } }
 
     it "commit using block and return commits stats" do
       mutations = [Google::Cloud::Spanner::V1::Mutation.new(
@@ -439,7 +439,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
       )]
       mock = Minitest::Mock.new
       mock.expect :create_session, session_grpc, [{database: database_path(instance_id, database_id), session: nil}, default_options]
-      mock.expect :commit, commit_stats_resp_grpc, [{ session: session_grpc.name, mutations: mutations, transaction_id: nil, single_use_transaction: tx_opts, return_commit_stats: true, request_options: nil }, default_options]
+      mock.expect :commit, commit_stats_resp_grpc, [{ session: session_grpc.name, mutations: mutations, transaction_id: nil, single_use_transaction: tx_opts, return_commit_stats: true, request_options: nil, max_commit_delay: nil }, default_options]
       spanner.service.mocked_service = mock
 
       commit_resp = client.commit commit_options: commit_options do |c|

--- a/google-cloud-spanner/test/google/cloud/spanner/client/commit_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/commit_test.rb
@@ -428,7 +428,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
   end
 
   describe "commit options" do
-    let(:commit_options) { { return_commit_stats: true, max_commit_delay: nil } }
+    let(:commit_options) { { return_commit_stats: true } }
 
     it "commit using block and return commits stats" do
       mutations = [Google::Cloud::Spanner::V1::Mutation.new(
@@ -439,7 +439,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
       )]
       mock = Minitest::Mock.new
       mock.expect :create_session, session_grpc, [{database: database_path(instance_id, database_id), session: nil}, default_options]
-      mock.expect :commit, commit_stats_resp_grpc, [{ session: session_grpc.name, mutations: mutations, transaction_id: nil, single_use_transaction: tx_opts, return_commit_stats: true, request_options: nil, max_commit_delay: nil }, default_options]
+      mock.expect :commit, commit_stats_resp_grpc, [{ session: session_grpc.name, mutations: mutations, transaction_id: nil, single_use_transaction: tx_opts, return_commit_stats: true, request_options: nil}, default_options]
       spanner.service.mocked_service = mock
 
       commit_resp = client.commit commit_options: commit_options do |c|
@@ -558,6 +558,29 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
       spanner.service.mocked_service = mock
 
       commit_resp = client.replace "users", [{ id: 4, name: "Henry", updated_at: client.commit_timestamp }], commit_options: commit_options
+      assert_commit_response commit_resp, commit_stats_resp_grpc
+
+      shutdown_client! client
+      mock.verify
+    end
+
+    it "commits with max_commit_delay" do
+      mutations = [Google::Cloud::Spanner::V1::Mutation.new(
+        update: Google::Cloud::Spanner::V1::Mutation::Write.new(
+          table: "users", columns: %w(id name active),
+          values: [Google::Cloud::Spanner::Convert.object_to_grpc_value([1, "Charlie", false]).list_value]
+        )
+      )]
+      commit_options[:max_commit_delay] = 120
+      mock = Minitest::Mock.new
+      mock.expect :create_session, session_grpc, [{database: database_path(instance_id, database_id), session: nil}, default_options]
+      mock.expect :commit, commit_stats_resp_grpc, [{ session: session_grpc.name, mutations: mutations, transaction_id: nil, single_use_transaction: tx_opts, return_commit_stats: true, max_commit_delay: 120, request_options: nil}, default_options]
+      spanner.service.mocked_service = mock
+
+      commit_resp = client.commit commit_options: commit_options do |c|
+        c.update "users", [{ id: 1, name: "Charlie", active: false }]
+      end
+
       assert_commit_response commit_resp, commit_stats_resp_grpc
 
       shutdown_client! client

--- a/google-cloud-spanner/test/google/cloud/spanner/client/commit_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/commit_test.rb
@@ -574,7 +574,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
       commit_options[:max_commit_delay] = 120
       mock = Minitest::Mock.new
       mock.expect :create_session, session_grpc, [{database: database_path(instance_id, database_id), session: nil}, default_options]
-      mock.expect :commit, commit_stats_resp_grpc, [{ session: session_grpc.name, mutations: mutations, transaction_id: nil, single_use_transaction: tx_opts, return_commit_stats: true, max_commit_delay: 120, request_options: nil}, default_options]
+      mock.expect :commit, commit_stats_resp_grpc, [{ session: session_grpc.name, mutations: mutations, transaction_id: nil, single_use_transaction: tx_opts, return_commit_stats: true, max_commit_delay: Google::Cloud::Spanner::Convert.number_to_duration(120, millisecond: true), request_options: nil}, default_options]
       spanner.service.mocked_service = mock
 
       commit_resp = client.commit commit_options: commit_options do |c|

--- a/google-cloud-spanner/test/google/cloud/spanner/convert/number_to_duration_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/convert/number_to_duration_test.rb
@@ -34,7 +34,7 @@ describe Google::Cloud::Spanner::Convert, :number_to_duration, :mock_spanner do
     duration = Google::Cloud::Spanner::Convert.number_to_duration number, millisecond: true
     _(duration).must_be_kind_of Google::Protobuf::Duration
     _(duration.seconds).must_equal 0
-    _(duration.nanos).must_equal 100000000
+    _(duration.nanos).must_equal 100_000_000
   end
 
   it "converts a negative Integer" do

--- a/google-cloud-spanner/test/google/cloud/spanner/convert/number_to_duration_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/convert/number_to_duration_test.rb
@@ -29,6 +29,14 @@ describe Google::Cloud::Spanner::Convert, :number_to_duration, :mock_spanner do
     _(duration.nanos).must_equal 0
   end
 
+  it "converts from millisecond" do
+    number = 100
+    duration = Google::Cloud::Spanner::Convert.number_to_duration number, millisecond: true
+    _(duration).must_be_kind_of Google::Protobuf::Duration
+    _(duration.seconds).must_equal 0
+    _(duration.nanos).must_equal 100000000
+  end
+
   it "converts a negative Integer" do
     number = -42
     duration = Google::Cloud::Spanner::Convert.number_to_duration number


### PR DESCRIPTION
- max_commit_delay says the latency for each request in milliseconds
- the input is given as Numeric and it is converted to Protobuf duration internally
- Value range is between 0 to 500ms

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/ruby-spanner/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea.
- [ ] Follow the instructions in [CONTRIBUTING](CONTRIBUTING.md). Most importantly, ensure the tests and linter pass by running `bundle exec rake ci` in the gem subdirectory.
- [ ] Update code documentation if necessary.

closes: #<issue_number_goes_here>