### PR TITLE
fix: Use https in Gemfile to avoid security vulnerability

### DIFF
--- a/google-cloud-spanner/Gemfile
+++ b/google-cloud-spanner/Gemfile
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 gemspec
 


### PR DESCRIPTION
We have a vulnerability [alert](https://github.com/googleapis/ruby-spanner/security/code-scanning/2) warning us to avoid `http` protocol in Gemfile. This PR addresses it.