### PR TITLE
Update the comment regarding root partitionability in batch_snapshot.rb

### DIFF
--- a/google-cloud-spanner/lib/google/cloud/spanner/batch_snapshot.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/batch_snapshot.rb
@@ -101,12 +101,13 @@ module Google
         # configured, although the values given may not necessarily be honored
         # depending on the query and options in the request.
         #
-        # The query must have a single [distributed
+        # The request will fail if the query is not root partitionable. For a
+        # query to be root partitionable, it needs to satisfy a few conditions.
+        # For example, if the query execution plan contains a [distributed
         # union](https://cloud.google.com/spanner/docs/query-execution-operators#distributed_union)
-        # operator at the root of the query plan. Such queries are
-        # root-partitionable. If a query cannot be partitioned at the root,
-        # Cloud Spanner cannot achieve the parallelism and in this case
-        # partition generation will fail.
+        # operator, then it must be the first operator in the plan. For more
+        # information about other conditions, see [Read data in
+        # parallel](https://cloud.google.com/spanner/docs/reads#read_data_in_parallel).
         #
         # @param [String] sql The SQL query string. See [Query
         #   syntax](https://cloud.google.com/spanner/docs/query-syntax).


### PR DESCRIPTION
With the recent release [1], we now support partition queries without a distributed union. The current comment is a bit outdated.

[1]: https://cloud.google.com/spanner/docs/release-notes#December_19_2023

closes: #100