### PR TITLE
chore: Resolve BigDecimal warning in Spanner

### DIFF
--- a/google-cloud-spanner/google-cloud-spanner.gemspec
+++ b/google-cloud-spanner/google-cloud-spanner.gemspec
@@ -18,9 +18,10 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.7"
 
+  gem.add_dependency "bigdecimal", "~> 3.0"
+  gem.add_dependency "concurrent-ruby", "~> 1.0"
   gem.add_dependency "google-cloud-core", "~> 1.5"
   gem.add_dependency "google-cloud-spanner-admin-database-v1", "~> 0.1"
   gem.add_dependency "google-cloud-spanner-admin-instance-v1", "~> 0.1"
   gem.add_dependency "google-cloud-spanner-v1", "~> 0.2"
-  gem.add_dependency "concurrent-ruby", "~> 1.0"
 end


### PR DESCRIPTION
This PR updates the Spanner gemspec to add an explicit dependency on the [bigdecimal gem](https://rubygems.org/gems/bigdecimal). This resolves the following warning:

```
warning: bigdecimal was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add bigdecimal to your Gemfile or gemspec.
```

closes: #97