### PR TITLE
chore: unskip PG tests against the emulator

### DIFF
--- a/google-cloud-spanner/acceptance/spanner/batch_client/execute_partition_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/batch_client/execute_partition_test.rb
@@ -18,11 +18,11 @@ describe "Spanner Batch Client", :execute_partition, :spanner do
   let(:db) { spanner_client }
   let(:pg_db) { spanner_pg_client }
   let(:batch_client) { $spanner.batch_client $spanner_instance_id, $spanner_database_id }
-  let(:pg_batch_client) { $spanner.batch_client $spanner_instance_id, $spanner_pg_database_id unless emulator_enabled? }
+  let(:pg_batch_client) { $spanner.batch_client $spanner_instance_id, $spanner_pg_database_id }
   let(:table_name) { "stuffs" }
   let(:table_index) { "IsStuffsIdPrime" }
   let(:batch_snapshot) { batch_client.batch_snapshot }
-  let(:pg_batch_snapshot) { pg_batch_client.batch_snapshot unless emulator_enabled? }
+  let(:pg_batch_snapshot) { pg_batch_client.batch_snapshot }
 
   before do
     db.delete table_name # remove all data
@@ -40,23 +40,21 @@ describe "Spanner Batch Client", :execute_partition, :spanner do
       { id: 11, bool: true },
       { id: 12, bool: false }
     ]
-    pg_db.delete table_name unless emulator_enabled?
-    unless emulator_enabled?
-      pg_db.insert table_name, [
-        { id: 1, bool: false },
-        { id: 2, bool: false },
-        { id: 3, bool: true },
-        { id: 4, bool: false },
-        { id: 5, bool: true },
-        { id: 6, bool: false },
-        { id: 7, bool: true },
-        { id: 8, bool: false },
-        { id: 9, bool: false },
-        { id: 10, bool: false },
-        { id: 11, bool: true },
-        { id: 12, bool: false }
-      ]
-    end
+    pg_db.delete table_name
+    pg_db.insert table_name, [
+      { id: 1, bool: false },
+      { id: 2, bool: false },
+      { id: 3, bool: true },
+      { id: 4, bool: false },
+      { id: 5, bool: true },
+      { id: 6, bool: false },
+      { id: 7, bool: true },
+      { id: 8, bool: false },
+      { id: 9, bool: false },
+      { id: 10, bool: false },
+      { id: 11, bool: true },
+      { id: 12, bool: false }
+    ]
   end
 
   after do
@@ -134,7 +132,6 @@ describe "Spanner Batch Client", :execute_partition, :spanner do
   end
 
   it "reads all by default in pg" do
-    skip if emulator_enabled?
     _(pg_batch_snapshot.timestamp).must_be_kind_of Time
     serialized_snapshot = pg_batch_snapshot.dump
 
@@ -226,7 +223,6 @@ describe "Spanner Batch Client", :execute_partition, :spanner do
   end
 
   it "queries all by default in pg" do
-    skip if emulator_enabled?
     pg_batch_snapshot = pg_batch_client.batch_snapshot
     serialized_snapshot = pg_batch_snapshot.dump
 
@@ -284,7 +280,6 @@ describe "Spanner Batch Client", :execute_partition, :spanner do
   end
 
   it "queries all by default with query options pg" do
-    skip if emulator_enabled?
     pg_batch_snapshot = pg_batch_client.batch_snapshot
     serialized_snapshot = pg_batch_snapshot.dump
 

--- a/google-cloud-spanner/acceptance/spanner/database_client_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/database_client_test.rb
@@ -62,7 +62,6 @@ describe "Spanner Databases Client", :spanner do
   end
 
   it "creates, gets, updates, and drops a database with pg dialect" do
-    skip if emulator_enabled?
     client = Google::Cloud::Spanner::Admin::Database.database_admin project_id: spanner.project
 
     instance_path = client.instance_path project: spanner.project, instance: instance_id

--- a/google-cloud-spanner/acceptance/spanner_helper.rb
+++ b/google-cloud-spanner/acceptance/spanner_helper.rb
@@ -142,13 +142,13 @@ raise GRPC::BadStatus.new(db_job.error.code, db_job.error.message) if db_job.err
 
 instance_path = $spanner_db_admin.instance_path project: $spanner.project_id, instance: $spanner_instance_id
 db_job = $spanner_db_admin.create_database parent: instance_path,
-                                             create_statement: "CREATE DATABASE \"#{$spanner_pg_database_id}\"",
-                                             database_dialect: :POSTGRESQL
+                                           create_statement: "CREATE DATABASE \"#{$spanner_pg_database_id}\"",
+                                           database_dialect: :POSTGRESQL
 db_job.wait_until_done!
 raise GRPC::BadStatus.new(db_job.error.code, db_job.error.message) if db_job.error?
 db_path = $spanner_db_admin.database_path project: $spanner.project_id,
-                                            instance: $spanner_instance_id,
-                                            database: $spanner_pg_database_id
+                                          instance: $spanner_instance_id,
+                                          database: $spanner_pg_database_id
 
 db_job = $spanner_db_admin.update_database_ddl database: db_path, statements: fixture.schema_pg_ddl_statements
 db_job.wait_until_done!


### PR DESCRIPTION
Unskip PG tests against the emulator which are disabled previously. Note that this needs to run against the latest emulator which includes FLOAT32 support. 