### PR TITLE
feat: Support setting the universe domain

### DIFF
--- a/google-cloud-spanner/lib/google-cloud-spanner.rb
+++ b/google-cloud-spanner/lib/google-cloud-spanner.rb
@@ -139,10 +139,8 @@ module Google
   end
 end
 
-# rubocop:disable Metrics/BlockLength
-
 # Set the default spanner configuration
-Google::Cloud.configure.add_config! :spanner do |config|
+Google::Cloud.configure.add_config! :spanner do |config| # rubocop:disable Metrics/BlockLength
   default_project = Google::Cloud::Config.deferred do
     ENV["SPANNER_PROJECT"]
   end
@@ -181,11 +179,10 @@ Google::Cloud.configure.add_config! :spanner do |config|
   config.add_field! :scope, default_scopes, match: [String, Array]
   config.add_field! :quota_project, nil, match: String
   config.add_field! :timeout, nil, match: Integer
-  config.add_field! :endpoint, "spanner.googleapis.com", match: String
+  config.add_field! :endpoint, nil, match: String
   config.add_field! :emulator_host, default_emulator, match: String, allow_nil: true
   config.add_field! :lib_name, nil, match: String, allow_nil: true
   config.add_field! :lib_version, nil, match: String, allow_nil: true
   config.add_field! :query_options, default_query_options, match: Hash, allow_nil: true
+  config.add_field! :universe_domain, nil, match: String, allow_nil: true
 end
-
-# rubocop:enable Metrics/BlockLength

--- a/google-cloud-spanner/lib/google/cloud/spanner.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner.rb
@@ -84,6 +84,7 @@ module Google
       #   with version.
       # @param enable_leader_aware_routing [Boolean] Specifies whether Leader
       #   Aware Routing should be enabled. Defaults to true.
+      # @param universe_domain [String] A custom universe domain. Optional.
       #
       # @return [Google::Cloud::Spanner::Project]
       #
@@ -95,7 +96,7 @@ module Google
       def self.new project_id: nil, credentials: nil, scope: nil, timeout: nil,
                    endpoint: nil, project: nil, keyfile: nil,
                    emulator_host: nil, lib_name: nil, lib_version: nil,
-                   enable_leader_aware_routing: true
+                   enable_leader_aware_routing: true, universe_domain: nil
         project_id    ||= project || default_project_id
         scope         ||= configure.scope
         timeout       ||= configure.timeout
@@ -104,6 +105,7 @@ module Google
         credentials   ||= keyfile
         lib_name      ||= configure.lib_name
         lib_version   ||= configure.lib_version
+        universe_domain ||= configure.universe_domain
 
         if emulator_host
           credentials = :this_channel_is_insecure
@@ -125,7 +127,7 @@ module Google
           Spanner::Service.new(
             project_id, credentials, quota_project: configure.quota_project,
             host: endpoint, timeout: timeout, lib_name: lib_name,
-            lib_version: lib_version,
+            lib_version: lib_version, universe_domain: universe_domain,
             enable_leader_aware_routing: enable_leader_aware_routing
           ),
           query_options: configure.query_options

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance.rb
@@ -85,6 +85,7 @@ module Google
           #
           def self.instance_admin project_id: nil,
                                   credentials: nil,
+                                  universe_domain: nil,
                                   scope: nil,
                                   timeout: nil,
                                   endpoint: nil,
@@ -93,14 +94,23 @@ module Google
                                   emulator_host: nil,
                                   lib_name: nil,
                                   lib_version: nil
-            project_id    ||= project || default_project_id
-            scope         ||= configure.scope
-            timeout       ||= configure.timeout
+            project_id ||= project || default_project_id
+            scope ||= configure.scope
+            timeout ||= configure.timeout
             emulator_host ||= configure.emulator_host
-            endpoint      ||= emulator_host || configure.endpoint
-            credentials   ||= keyfile
-            lib_name      ||= configure.lib_name
-            lib_version   ||= configure.lib_version
+            # TODO: This logic is part of UniverseDomainConcerns in gapic-common
+            # but is being copied here because we need to determine the host up
+            # front in order to build a gRPC channel. We should refactor this
+            # somehow to allow this logic to live where it is supposed to.
+            universe_domain ||= configure.universe_domain || ENV["GOOGLE_CLOUD_UNIVERSE_DOMAIN"] || "googleapis.com"
+            endpoint ||= emulator_host || configure.endpoint
+            endpoint ||=
+              Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdmin::Client::DEFAULT_ENDPOINT_TEMPLATE.sub(
+                Gapic::UniverseDomainConcerns::ENDPOINT_SUBSTITUTION, universe_domain
+              )
+            credentials ||= keyfile
+            lib_name ||= configure.lib_name
+            lib_version ||= configure.lib_version
 
             if emulator_host
               credentials = :this_channel_is_insecure
@@ -121,10 +131,11 @@ module Google
             configure.quota_project ||= credentials.quota_project_id if credentials.respond_to? :quota_project_id
 
             Admin::Instance::V1::InstanceAdmin::Client.new do |config|
+              config.universe_domain = universe_domain
               config.credentials = channel endpoint, credentials
               config.quota_project = configure.quota_project
               config.timeout = timeout if timeout
-              config.endpoint = endpoint if endpoint
+              config.endpoint = endpoint
               config.lib_name = lib_name_with_prefix lib_name, lib_version
               config.lib_version = Google::Cloud::Spanner::VERSION
               config.metadata = { "google-cloud-resource-prefix" => "projects/#{project_id}" }
@@ -290,7 +301,7 @@ module Google
           class Configuration
             extend ::Gapic::Config
 
-            config_attr :endpoint,      "spanner.googleapis.com", ::String
+            config_attr :endpoint,      nil, ::String
             config_attr :credentials,   nil do |value|
               allowed = [::String, ::Hash, ::Google::Auth::Credentials, ::Signet::OAuth2::Client, nil]
               allowed += [::GRPC::Core::Channel, ::GRPC::Core::ChannelCredentials] if defined? ::GRPC
@@ -307,6 +318,7 @@ module Google
             config_attr :query_options, nil, ::Hash,    nil
             config_attr :metadata,      nil, ::Hash,    nil
             config_attr :retry_policy,  nil, ::Hash,    nil
+            config_attr :universe_domain, nil, ::String, nil
 
             # @private
             def initialize parent_config = nil

--- a/google-cloud-spanner/lib/google/cloud/spanner/project.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/project.rb
@@ -96,6 +96,15 @@ module Google
         alias project project_id
 
         ##
+        # The universe domain the client is connected to
+        #
+        # @return [String]
+        #
+        def universe_domain
+          service.universe_domain
+        end
+
+        ##
         # Retrieves the list of Cloud Spanner instances for the project.
         #
         # @param [String] token The `token` value returned by the last call to

--- a/google-cloud-spanner/test/google/cloud/spanner/project_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/project_test.rb
@@ -31,6 +31,17 @@ describe Google::Cloud::Spanner::Project, :mock_spanner do
     _(spanner.project_id).must_equal project
   end
 
+  it "returns the default universe domain" do
+    _(spanner.universe_domain).must_equal "googleapis.com"
+  end
+
+  it "returns a custom universe domain" do
+    universe = "myuniverse.com"
+    service = Google::Cloud::Spanner::Service.new project, credentials, universe_domain: universe
+    spanner = Google::Cloud::Spanner::Project.new service
+    _(spanner.universe_domain).must_equal universe
+  end
+
   it "creates client with database role" do
     mock = Minitest::Mock.new
     request_session = Google::Cloud::Spanner::V1::Session.new labels: nil, creator_role: "test_role"

--- a/google-cloud-spanner/test/google/cloud/spanner/service_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/service_test.rb
@@ -20,7 +20,7 @@ describe Google::Cloud::Spanner::Service, :mock_spanner  do
   let(:session_id) { "session123" }
   let(:default_options) { ::Gapic::CallOptions.new metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
   let(:session_grpc) { Google::Cloud::Spanner::V1::Session.new name: session_path(instance_id, database_id, session_id) }
-  let(:basic_service) { Google::Cloud::Spanner::Service.new "test_project", nil }
+  let(:basic_service) { Google::Cloud::Spanner::Service.new "test_project", :this_channel_is_insecure }
   let(:expected_call_opts) {
     metadata = {
       "google-cloud-resource-prefix" => session_id
@@ -32,7 +32,7 @@ describe Google::Cloud::Spanner::Service, :mock_spanner  do
     it "sets quota_project with given value" do
       expected_quota_project = "test_quota_project"
       service = Google::Cloud::Spanner::Service.new(
-        "test_project", nil, quota_project: expected_quota_project
+        "test_project", :this_channel_is_insecure, quota_project: expected_quota_project
       )
       assert_equal expected_quota_project, service.quota_project
     end
@@ -45,6 +45,16 @@ describe Google::Cloud::Spanner::Service, :mock_spanner  do
       assert_equal expected_quota_project, service.quota_project
     end
 
+    it "uses the default universe domain" do
+      assert_equal "googleapis.com", basic_service.universe_domain
+      assert_equal "spanner.googleapis.com", basic_service.host
+    end
+
+    it "sets a custom universe domain" do
+      service = Google::Cloud::Spanner::Service.new "test_project", :this_channel_is_insecure, universe_domain: "myuniverse.com"
+      assert_equal "myuniverse.com", service.universe_domain
+      assert_equal "spanner.myuniverse.com", service.host
+    end
   end
 
   describe ".create_session" do

--- a/google-cloud-spanner/test/google/cloud/spanner_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner_test.rb
@@ -125,12 +125,11 @@ describe Google::Cloud do
         _(scope).must_equal default_scope
         "spanner-credentials"
       }
-      stubbed_service = ->(project, credentials, timeout: nil, host: nil, **keyword_args) {
+      stubbed_service = ->(project, credentials, timeout: nil, **keyword_args) {
 
         _(project).must_equal "project-id"
         _(credentials).must_equal "spanner-credentials"
         _(timeout).must_be :nil?
-        _(host).must_equal "spanner.googleapis.com"
         _(keyword_args.key?(:lib_name)).must_equal true
         _(keyword_args.key?(:lib_version)).must_equal true
         _(keyword_args[:lib_name]).must_be :nil?
@@ -179,6 +178,7 @@ describe Google::Cloud do
             _(spanner.service.lib_name).must_be :nil?
             _(spanner.service.lib_version).must_be :nil?
             _(spanner.service.send(:lib_name_with_prefix)).must_equal "gccl"
+            _(spanner.universe_domain).must_equal "googleapis.com"
           end
         end
       end
@@ -190,11 +190,10 @@ describe Google::Cloud do
         _(scope).wont_be :nil?
         "spanner-credentials"
       }
-      stubbed_service = ->(project, credentials, timeout: nil, host: nil, **keyword_args) {
+      stubbed_service = ->(project, credentials, timeout: nil, **keyword_args) {
         _(project).must_equal "project-id"
         _(credentials).must_equal "spanner-credentials"
         _(timeout).must_be :nil?
-        _(host).wont_be :nil?
         _(keyword_args.key?(:lib_name)).must_equal true
         _(keyword_args.key?(:lib_version)).must_equal true
         _(keyword_args[:lib_name]).must_be :nil?
@@ -215,6 +214,26 @@ describe Google::Cloud do
               end
             end
           end
+        end
+      end
+    end
+
+    it "uses provided universe domain" do
+      universe = "my-universe.com"
+      stubbed_service = ->(project, credentials, universe_domain: nil, **keyword_args) {
+        _(project).must_equal "project-id"
+        _(credentials).must_equal default_credentials
+        _(universe_domain).must_equal universe
+        OpenStruct.new project: project, universe_domain: universe_domain
+      }
+
+      # Clear all environment variables
+      ENV.stub :[], nil do
+        Google::Cloud::Spanner::Service.stub :new, stubbed_service do
+          spanner = Google::Cloud::Spanner.new project: "project-id", credentials: default_credentials, universe_domain: universe
+          _(spanner).must_be_kind_of Google::Cloud::Spanner::Project
+          _(spanner.project).must_equal "project-id"
+          _(spanner.service).must_be_kind_of OpenStruct
         end
       end
     end
@@ -305,11 +324,10 @@ describe Google::Cloud do
         _(scope).wont_be :nil?
         "spanner-credentials"
       }
-      stubbed_service = ->(project, credentials, timeout: nil, host: nil, **keyword_args) {
+      stubbed_service = ->(project, credentials, timeout: nil, **keyword_args) {
         _(project).must_equal "project-id"
         _(credentials).must_equal "spanner-credentials"
         _(timeout).must_be :nil?
-        _(host).wont_be :nil?
         _(keyword_args.key?(:lib_name)).must_equal true
         _(keyword_args.key?(:lib_version)).must_equal true
         _(keyword_args[:lib_name]).must_be :nil?
@@ -340,12 +358,11 @@ describe Google::Cloud do
         _(scope).wont_be :nil?
         OpenStruct.new project_id: "project-id"
       }
-      stubbed_service = ->(project, credentials, timeout: nil, host: nil, **keyword_args) {
+      stubbed_service = ->(project, credentials, timeout: nil, **keyword_args) {
         _(project).must_equal "project-id"
         _(credentials).must_be_kind_of OpenStruct
         _(credentials.project_id).must_equal "project-id"
         _(timeout).must_be :nil?
-        _(host).wont_be :nil?
         _(keyword_args.key?(:lib_name)).must_equal true
         _(keyword_args.key?(:lib_version)).must_equal true
         _(keyword_args[:lib_name]).must_be :nil?
@@ -563,11 +580,10 @@ describe Google::Cloud do
     end
 
     it "uses shared config for project and keyfile" do
-      stubbed_service = ->(project, credentials, timeout: nil, host: nil, **keyword_args) {
+      stubbed_service = ->(project, credentials, timeout: nil, **keyword_args) {
         _(project).must_equal "project-id"
         _(credentials).must_equal "spanner-credentials"
         _(timeout).must_be :nil?
-        _(host).wont_be :nil?
         _(keyword_args.key?(:lib_name)).must_equal true
         _(keyword_args.key?(:lib_version)).must_equal true
         _(keyword_args[:lib_name]).must_be :nil?
@@ -599,11 +615,10 @@ describe Google::Cloud do
     end
 
     it "uses shared config for project_id and credentials" do
-      stubbed_service = ->(project, credentials, timeout: nil, host: nil, **keyword_args) {
+      stubbed_service = ->(project, credentials, timeout: nil, **keyword_args) {
         _(project).must_equal "project-id"
         _(credentials).must_equal "spanner-credentials"
         _(timeout).must_be :nil?
-        _(host).wont_be :nil?
         _(keyword_args.key?(:lib_name)).must_equal true
         _(keyword_args.key?(:lib_version)).must_equal true
         _(keyword_args[:lib_name]).must_be :nil?
@@ -635,11 +650,10 @@ describe Google::Cloud do
     end
 
     it "uses spanner config for project and keyfile" do
-      stubbed_service = ->(project, credentials, timeout: nil, host: nil, **keyword_args) {
+      stubbed_service = ->(project, credentials, timeout: nil, **keyword_args) {
         _(project).must_equal "project-id"
         _(credentials).must_equal "spanner-credentials"
         _(timeout).must_equal 42
-        _(host).wont_be :nil?
         _(keyword_args.key?(:lib_name)).must_equal true
         _(keyword_args.key?(:lib_version)).must_equal true
         _(keyword_args[:lib_name]).must_be :nil?
@@ -672,11 +686,10 @@ describe Google::Cloud do
     end
 
     it "uses spanner config for project_id and credentials" do
-      stubbed_service = ->(project, credentials, timeout: nil, host: nil, **keyword_args) {
+      stubbed_service = ->(project, credentials, timeout: nil, **keyword_args) {
         _(project).must_equal "project-id"
         _(credentials).must_equal "spanner-credentials"
         _(timeout).must_equal 42
-        _(host).wont_be :nil?
         _(keyword_args.key?(:lib_name)).must_equal true
         _(keyword_args.key?(:lib_version)).must_equal true
         _(keyword_args[:lib_name]).must_be :nil?
@@ -772,11 +785,10 @@ describe Google::Cloud do
         _(scope).wont_be :nil?
         "spanner-credentials"
       }
-      stubbed_service = ->(project, credentials, timeout: nil, host: nil, **keyword_args) {
+      stubbed_service = ->(project, credentials, timeout: nil, **keyword_args) {
         _(project).must_equal "project-id"
         _(credentials).must_equal "spanner-credentials"
         _(timeout).must_be :nil?
-        _(host).wont_be :nil?
         _(keyword_args[:lib_name]).must_equal custom_lib_name
         _(keyword_args[:lib_version]).must_equal custom_lib_version
         OpenStruct.new project: project, lib_name: keyword_args[:lib_name], lib_version: keyword_args[:lib_version]


### PR DESCRIPTION
Spanner unfortunately needed a bit of a hack for proper universe_domain behavior. Normally, we just pass the universe domain down into the gapic-common layer and it will generate the correct endpoint host name. However, Spanner uses a prebuilt gRPC channel as a credential because of how it configures gRPC, which means we need to know the endpoint up front in order to construct that channel. Thus, we are currently copying from gapic-common (and settings from the GAPIC) to resolve the universe domain, and thus the endpoint. Later we will need to refactor things a bit to expose this logic either in the gapic-common layer or in the generated GAPIC, so the Spanner handwritten client can just call it directly.