### PR TITLE
fix: Corrected algorithm that releases stale sessions in the pool

### DIFF
--- a/google-cloud-spanner/lib/google/cloud/spanner/pool.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/pool.rb
@@ -136,10 +136,10 @@ module Google
 
           @mutex.synchronize do
             available_count = sessions_available.count
-            release_count = @min - available_count
+            release_count = available_count - @min
             release_count = 0 if release_count.negative?
 
-            to_keepalive += sessions_available.select do |x|
+            to_keepalive = sessions_available.select do |x|
               x.idle_since? @keepalive
             end
 


### PR DESCRIPTION
This seems like a bad bug that releases stale sessions incorrectly: instead of releasing stale sessions down to the min level (as I assume we're supposed to), it releases more sessions if the number is below the min, but never releases sessions if the number is above the min. Fixed and added tests.