### PR TITLE
chore: remove api-spanne-ruby from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,5 +8,3 @@
 # @googleapis/cloud-sdk-ruby-team is the default owner for anything not
 # explicitly taken by someone else.
 *                                    @googleapis/cloud-sdk-ruby-team
-
-/google-cloud-spanner*/              @googleapis/cloud-sdk-ruby-team @googleapis/api-spanner-ruby


### PR DESCRIPTION
The Cloud SDK Ruby team maintains this project. I've deleted the api-spanner-ruby team.
