### PR TITLE
feat(spanner): allow setting transaction options at client level

### DIFF
--- a/google-cloud-spanner/lib/google/cloud/spanner/client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/client.rb
@@ -71,10 +71,25 @@ module Google
         # @param directed_read_options [::Hash, nil] Optional. Client options used to set
         #   the `directed_read_options` for all ReadRequests and ExecuteSqlRequests.
         #   Converts to `V1::DirectedReadOptions`. Example option: `:exclude_replicas`.
+        # @param isolation_level [::Symbol, nil] Optional. The isolation level for the transactions.
+        #   Can be overridden by the isolation level set on the transaction.
+        #   Can be one of the following:
+        #   * `:ISOLATION_LEVEL_UNSPECIFIED` : The default unspecified isolation level.
+        #   * `:SERIALIZABLE` : The serializable isolation level.
+        #   * `:REPEATABLE_READ` : The repeatable read isolation level.
+        # @param read_lock_mode [::Symbol, nil] Optional. The read lock mode for the transactions.
+        #   Can be overridden by the read lock mode set on the transaction.
+        #   Can be one of the following:
+        #   * `:READ_LOCK_MODE_UNSPECIFIED` : The default unspecified read lock mode.
+        #   * `:PESSIMISTIC` : The pessimistic lock mode, where depending on the isolation level and/or lock
+        #       requested, locks are acquired on read.
+        #   * `:OPTIMISTIC` : The optimistic lock mode, where locks are not acquired on read. Depending on the
+        #       isolation level and/or lock requested on a read, data may be validated at commit time to be not
+        #       changed since the transaction started.
         # @private
         def initialize project, instance_id, database_id, session_labels: nil,
                        pool_opts: {}, query_options: nil, database_role: nil,
-                       directed_read_options: nil
+                       directed_read_options: nil, isolation_level: nil, read_lock_mode: nil
           @project = project
           @instance_id = instance_id
           @database_id = database_id
@@ -82,6 +97,8 @@ module Google
           @session_labels = session_labels
           @query_options = query_options
           @directed_read_options = directed_read_options
+          @isolation_level = isolation_level
+          @read_lock_mode = read_lock_mode
 
           _pool_opts = pool_opts # unused. Here only to avoid having to disable Rubocop's Lint/UnusedMethodArgument
 
@@ -1070,8 +1087,6 @@ module Google
         # @param [Boolean] exclude_txn_from_change_streams If set to true,
         #   mutations will not be recorded in change streams with DDL option
         #   `allow_txn_exclusion=true`.
-        # @param [Google::Cloud::Spanner::V1::TransactionOptions::IsolationLevel] isolation_level Optional. The
-        #   isolation level for the transaction.
         # @param [Hash] commit_options A hash of commit options.
         #   e.g., return_commit_stats. Commit options are optional.
         #   The following options can be provided:
@@ -1109,12 +1124,22 @@ module Google
         #       trigger a retry.
         #
         # @param [Google::Cloud::Spanner::V1::TransactionOptions::ReadWrite::ReadLockMode] read_lock_mode
-        #   The read lock mode for the transaction.
+        #   The read lock mode for the transaction. If not specified, the client-level read lock
+        #   mode will be used.
         #   Can be one of the following:
         #   * `:READ_LOCK_MODE_UNSPECIFIED` : The default unspecified read lock mode.
-        #   * `:PESSIMISTIC` : The pessimistic lock mode, where read locks are acquired immediately on read.
-        #   * `:OPTIMISTIC` : The optimistic lock mode, where locks for reads are not acquired on read
-        #       but instead on a commit to validate that the data has not changed since the transaction started.
+        #   * `:PESSIMISTIC` : The pessimistic lock mode, where depending on the isolation level and/or lock
+        #       requested, locks are acquired on read.
+        #   * `:OPTIMISTIC` : The optimistic lock mode, where locks are not acquired on read. Depending on the
+        #       isolation level and/or lock requested on a read, data may be validated at commit time to be not
+        #       changed since the transaction started.
+        #
+        # @param isolation_level [::Symbol, nil] Optional. The isolation level for the transaction.
+        #   If not specified, the client-level isolation level will be used.
+        #   Can be one of the following:
+        #   * `:ISOLATION_LEVEL_UNSPECIFIED` : The default unspecified isolation level.
+        #   * `:SERIALIZABLE` : The serializable isolation level.
+        #   * `:REPEATABLE_READ` : The repeatable read isolation level.
         #
         # @return [Time, CommitResponse] The timestamp at which the operation
         #   committed. If commit options are set it returns {CommitResponse}.
@@ -1178,11 +1203,11 @@ module Google
           @pool.with_session do |session|
             session.upsert table, rows,
                            exclude_txn_from_change_streams: exclude_txn_from_change_streams,
-                           isolation_level: isolation_level,
+                           isolation_level: isolation_level || @isolation_level,
                            commit_options: commit_options,
                            request_options: request_options,
                            call_options: call_options,
-                           read_lock_mode: read_lock_mode
+                           read_lock_mode: read_lock_mode || @read_lock_mode
           end
         end
         alias save upsert
@@ -1229,8 +1254,6 @@ module Google
         # @param [Boolean] exclude_txn_from_change_streams If set to true,
         #   mutations will not be recorded in change streams with DDL option
         #   `allow_txn_exclusion=true`.
-        # @param [Google::Cloud::Spanner::V1::TransactionOptions::IsolationLevel] isolation_level Optional. The
-        #   isolation level for the transaction.
         # @param [Hash] commit_options A hash of commit options.
         #   e.g., return_commit_stats. Commit options are optional.
         #   The following options can be provided:
@@ -1269,13 +1292,22 @@ module Google
         #
         #
         # @param [Google::Cloud::Spanner::V1::TransactionOptions::ReadWrite::ReadLockMode] read_lock_mode
-        #   The read lock mode for the transaction.
+        #   The read lock mode for the transaction. If not specified, the client-level read lock
+        #   mode will be used.
         #   Can be one of the following:
         #   * `:READ_LOCK_MODE_UNSPECIFIED` : The default unspecified read lock mode.
-        #   * `:PESSIMISTIC` : The pessimistic lock mode, where read locks are acquired immediately on read.
-        #   * `:OPTIMISTIC` : The optimistic lock mode, where locks for reads are not acquired on read
-        #       but instead on a commit to validate that the data has not changed since the transaction started.
+        #   * `:PESSIMISTIC` : The pessimistic lock mode, where depending on the isolation level and/or lock
+        #       requested, locks are acquired on read.
+        #   * `:OPTIMISTIC` : The optimistic lock mode, where locks are not acquired on read. Depending on the
+        #       isolation level and/or lock requested on a read, data may be validated at commit time to be not
+        #       changed since the transaction started.
         #
+        # @param isolation_level [::Symbol, nil] Optional. The isolation level for the transaction.
+        #   If not specified, the client-level isolation level will be used.
+        #   Can be one of the following:
+        #   * `:ISOLATION_LEVEL_UNSPECIFIED` : The default unspecified isolation level.
+        #   * `:SERIALIZABLE` : The serializable isolation level.
+        #   * `:REPEATABLE_READ` : The repeatable read isolation level.
         #
         # @return [Time, CommitResponse] The timestamp at which the operation
         #   committed. If commit options are set it returns {CommitResponse}.
@@ -1339,11 +1371,11 @@ module Google
           @pool.with_session do |session|
             session.insert table, rows,
                            exclude_txn_from_change_streams: exclude_txn_from_change_streams,
-                           isolation_level: isolation_level,
+                           isolation_level: isolation_level || @isolation_level,
                            commit_options: commit_options,
                            request_options: request_options,
                            call_options: call_options,
-                           read_lock_mode: read_lock_mode
+                           read_lock_mode: read_lock_mode || @read_lock_mode
           end
         end
 
@@ -1389,8 +1421,6 @@ module Google
         # @param [Boolean] exclude_txn_from_change_streams If set to true,
         #   mutations will not be recorded in change streams with DDL option
         #   `allow_txn_exclusion=true`.
-        # @param [Google::Cloud::Spanner::V1::TransactionOptions::IsolationLevel] isolation_level Optional. The
-        #   isolation level for the transaction.
         # @param [Hash] commit_options A hash of commit options.
         #   e.g., return_commit_stats. Commit options are optional.
         #   The following options can be provided:
@@ -1428,13 +1458,22 @@ module Google
         #       trigger a retry.
         #
         # @param [Google::Cloud::Spanner::V1::TransactionOptions::ReadWrite::ReadLockMode] read_lock_mode
-        #   The read lock mode for the transaction.
+        #   The read lock mode for the transaction. If not specified, the client-level read lock
+        #   mode will be used.
         #   Can be one of the following:
         #   * `:READ_LOCK_MODE_UNSPECIFIED` : The default unspecified read lock mode.
-        #   * `:PESSIMISTIC` : The pessimistic lock mode, where read locks are acquired immediately on read.
-        #   * `:OPTIMISTIC` : The optimistic lock mode, where locks for reads are not acquired on read
-        #       but instead on a commit to validate that the data has not changed since the transaction started.
+        #   * `:PESSIMISTIC` : The pessimistic lock mode, where depending on the isolation level and/or lock
+        #       requested, locks are acquired on read.
+        #   * `:OPTIMISTIC` : The optimistic lock mode, where locks are not acquired on read. Depending on the
+        #       isolation level and/or lock requested on a read, data may be validated at commit time to be not
+        #       changed since the transaction started.
         #
+        # @param isolation_level [::Symbol, nil] Optional. The isolation level for the transaction.
+        #   If not specified, the client-level isolation level will be used.
+        #   Can be one of the following:
+        #   * `:ISOLATION_LEVEL_UNSPECIFIED` : The default unspecified isolation level.
+        #   * `:SERIALIZABLE` : The serializable isolation level.
+        #   * `:REPEATABLE_READ` : The repeatable read isolation level.
         #
         # @return [Time, CommitResponse] The timestamp at which the operation
         #   committed. If commit options are set it returns {CommitResponse}.
@@ -1497,11 +1536,11 @@ module Google
           @pool.with_session do |session|
             session.update table, rows,
                            exclude_txn_from_change_streams: exclude_txn_from_change_streams,
-                           isolation_level: isolation_level,
+                           isolation_level: isolation_level || @isolation_level,
                            commit_options: commit_options,
                            request_options: request_options,
                            call_options: call_options,
-                           read_lock_mode: read_lock_mode
+                           read_lock_mode: read_lock_mode || @read_lock_mode
           end
         end
 
@@ -1549,8 +1588,6 @@ module Google
         # @param [Boolean] exclude_txn_from_change_streams If set to true,
         #   mutations will not be recorded in change streams with DDL option
         #   `allow_txn_exclusion=true`.
-        # @param [Google::Cloud::Spanner::V1::TransactionOptions::IsolationLevel] isolation_level Optional. The
-        #   isolation level for the transaction.
         # @param [Hash] commit_options A hash of commit options.
         #   e.g., return_commit_stats. Commit options are optional.
         #   The following options can be provided:
@@ -1588,13 +1625,22 @@ module Google
         #       trigger a retry.
         #
         # @param [Google::Cloud::Spanner::V1::TransactionOptions::ReadWrite::ReadLockMode] read_lock_mode
-        #   The read lock mode for the transaction.
+        #   The read lock mode for the transaction. If not specified, the client-level read lock
+        #   mode will be used.
         #   Can be one of the following:
         #   * `:READ_LOCK_MODE_UNSPECIFIED` : The default unspecified read lock mode.
-        #   * `:PESSIMISTIC` : The pessimistic lock mode, where read locks are acquired immediately on read.
-        #   * `:OPTIMISTIC` : The optimistic lock mode, where locks for reads are not acquired on read
-        #       but instead on a commit to validate that the data has not changed since the transaction started.
+        #   * `:PESSIMISTIC` : The pessimistic lock mode, where depending on the isolation level and/or lock
+        #       requested, locks are acquired on read.
+        #   * `:OPTIMISTIC` : The optimistic lock mode, where locks are not acquired on read. Depending on the
+        #       isolation level and/or lock requested on a read, data may be validated at commit time to be not
+        #       changed since the transaction started.
         #
+        # @param isolation_level [::Symbol, nil] Optional. The isolation level for the transaction.
+        #   If not specified, the client-level isolation level will be used.
+        #   Can be one of the following:
+        #   * `:ISOLATION_LEVEL_UNSPECIFIED` : The default unspecified isolation level.
+        #   * `:SERIALIZABLE` : The serializable isolation level.
+        #   * `:REPEATABLE_READ` : The repeatable read isolation level.
         #
         # @return [Time, CommitResponse] The timestamp at which the operation
         #   committed. If commit options are set it returns {CommitResponse}.
@@ -1654,11 +1700,11 @@ module Google
           @pool.with_session do |session|
             session.replace table, rows,
                             exclude_txn_from_change_streams: exclude_txn_from_change_streams,
-                            isolation_level: isolation_level,
+                            isolation_level: isolation_level || @isolation_level,
                             commit_options: commit_options,
                             request_options: request_options,
                             call_options: call_options,
-                            read_lock_mode: read_lock_mode
+                            read_lock_mode: read_lock_mode || @read_lock_mode
           end
         end
 
@@ -1685,8 +1731,6 @@ module Google
         # @param [Boolean] exclude_txn_from_change_streams If set to true,
         #   mutations will not be recorded in change streams with DDL option
         #   `allow_txn_exclusion=true`.
-        # @param [Google::Cloud::Spanner::V1::TransactionOptions::IsolationLevel] isolation_level Optional. The
-        #   isolation level for the transaction.
         # @param [Hash] commit_options A hash of commit options.
         #   e.g., return_commit_stats. Commit options are optional.
         #   The following options can be provided:
@@ -1724,13 +1768,22 @@ module Google
         #       trigger a retry.
         #
         # @param [Google::Cloud::Spanner::V1::TransactionOptions::ReadWrite::ReadLockMode] read_lock_mode
-        #   The read lock mode for the transaction.
+        #   The read lock mode for the transaction. If not specified, the client-level read lock
+        #   mode will be used.
         #   Can be one of the following:
         #   * `:READ_LOCK_MODE_UNSPECIFIED` : The default unspecified read lock mode.
-        #   * `:PESSIMISTIC` : The pessimistic lock mode, where read locks are acquired immediately on read.
-        #   * `:OPTIMISTIC` : The optimistic lock mode, where locks for reads are not acquired on read
-        #       but instead on a commit to validate that the data has not changed since the transaction started.
+        #   * `:PESSIMISTIC` : The pessimistic lock mode, where depending on the isolation level and/or lock
+        #       requested, locks are acquired on read.
+        #   * `:OPTIMISTIC` : The optimistic lock mode, where locks are not acquired on read. Depending on the
+        #       isolation level and/or lock requested on a read, data may be validated at commit time to be not
+        #       changed since the transaction started.
         #
+        # @param isolation_level [::Symbol, nil] Optional. The isolation level for the transaction.
+        #   If not specified, the client-level isolation level will be used.
+        #   Can be one of the following:
+        #   * `:ISOLATION_LEVEL_UNSPECIFIED` : The default unspecified isolation level.
+        #   * `:SERIALIZABLE` : The serializable isolation level.
+        #   * `:REPEATABLE_READ` : The repeatable read isolation level.
         #
         # @return [Time, CommitResponse] The timestamp at which the operation
         #   committed. If commit options are set it returns {CommitResponse}.
@@ -1787,11 +1840,11 @@ module Google
           @pool.with_session do |session|
             session.delete table, keys,
                            exclude_txn_from_change_streams: exclude_txn_from_change_streams,
-                           isolation_level: isolation_level,
+                           isolation_level: isolation_level || @isolation_level,
                            commit_options: commit_options,
                            request_options: request_options,
                            call_options: call_options,
-                           read_lock_mode: read_lock_mode
+                           read_lock_mode: read_lock_mode || @read_lock_mode
           end
         end
 
@@ -1813,8 +1866,6 @@ module Google
         # @param [Boolean] exclude_txn_from_change_streams If set to true,
         #   mutations will not be recorded in change streams with DDL option
         #   `allow_txn_exclusion=true`.
-        # @param [Google::Cloud::Spanner::V1::TransactionOptions::IsolationLevel] isolation_level Optional. The
-        #   isolation level for the transaction.
         # @param [Hash] commit_options A hash of commit options.
         #   e.g., return_commit_stats. Commit options are optional.
         #   The following options can be provided:
@@ -1855,13 +1906,20 @@ module Google
         # @yieldparam [Google::Cloud::Spanner::Commit] commit The Commit object.
         #
         # @param [Google::Cloud::Spanner::V1::TransactionOptions::ReadWrite::ReadLockMode] read_lock_mode
-        #   The read lock mode for the transaction.
+        #   The read lock mode for the transaction. If not specified, the client-level read lock
+        #   moce will be used.
         #   Can be one of the following:
         #   * `:READ_LOCK_MODE_UNSPECIFIED` : The default unspecified read lock mode.
         #   * `:PESSIMISTIC` : The pessimistic lock mode, where read locks are acquired immediately on read.
         #   * `:OPTIMISTIC` : The optimistic lock mode, where locks for reads are not acquired on read
         #       but instead on a commit to validate that the data has not changed since the transaction started.
         #
+        # @param isolation_level [::Symbol, nil] Optional. The isolation level for the transaction.
+        #   If not specified, the client-level isolation level will be used.
+        #   Can be one of the following:
+        #   * `:ISOLATION_LEVEL_UNSPECIFIED` : The default unspecified isolation level.
+        #   * `:SERIALIZABLE` : The serializable isolation level.
+        #   * `:REPEATABLE_READ` : The repeatable read isolation level.
         #
         # @return [Time, CommitResponse] The timestamp at which the operation
         #   committed. If commit options are set it returns {CommitResponse}.
@@ -1930,11 +1988,11 @@ module Google
           @pool.with_session do |session|
             session.commit(
               exclude_txn_from_change_streams: exclude_txn_from_change_streams,
-              isolation_level: isolation_level,
+              isolation_level: isolation_level || @isolation_level,
               commit_options: commit_options,
               request_options: request_options,
               call_options: call_options,
-              read_lock_mode: read_lock_mode,
+              read_lock_mode: read_lock_mode || @read_lock_mode,
               &block
             )
           end
@@ -2102,12 +2160,22 @@ module Google
         #       trigger a retry.
         #
         # @param [Google::Cloud::Spanner::V1::TransactionOptions::ReadWrite::ReadLockMode] read_lock_mode
-        #   The read lock mode for the transaction.
+        #   The read lock mode for the transaction. If not specified, the client-level read lock
+        #   mode will be used.
         #   Can be one of the following:
         #   * `:READ_LOCK_MODE_UNSPECIFIED` : The default unspecified read lock mode.
-        #   * `:PESSIMISTIC` : The pessimistic lock mode, where read locks are acquired immediately on read.
-        #   * `:OPTIMISTIC` : The optimistic lock mode, where locks for reads are not acquired on read
-        #       but instead on a commit to validate that the data has not changed since the transaction started.
+        #   * `:PESSIMISTIC` : The pessimistic lock mode, where depending on the isolation level and/or lock
+        #       requested, locks are acquired on read.
+        #   * `:OPTIMISTIC` : The optimistic lock mode, where locks are not acquired on read. Depending on the
+        #       isolation level and/or lock requested on a read, data may be validated at commit time to be not
+        #       changed since the transaction started.
+        #
+        # @param isolation_level [::Symbol, nil] Optional. The isolation level for the transaction.
+        #   If not specified, the client-level isolation level will be used.
+        #   Can be one of the following:
+        #   * `:ISOLATION_LEVEL_UNSPECIFIED` : The default unspecified isolation level.
+        #   * `:SERIALIZABLE` : The serializable isolation level.
+        #   * `:REPEATABLE_READ` : The repeatable read isolation level.
         #
         #
         # @yield [transaction] The block for reading and writing data.
@@ -2212,7 +2280,8 @@ module Google
         #   end
         #
         def transaction deadline: 120, exclude_txn_from_change_streams: false,
-                        commit_options: nil, request_options: nil, call_options: nil, read_lock_mode: nil
+                        commit_options: nil, request_options: nil, call_options: nil, read_lock_mode: nil,
+                        isolation_level: nil
           ensure_service!
           unless Thread.current[IS_TRANSACTION_RUNNING_KEY].nil?
             raise "Nested transactions are not allowed"
@@ -2229,8 +2298,9 @@ module Google
             transaction_tag = request_options[:transaction_tag] if request_options
             tx = session.create_empty_transaction \
               exclude_txn_from_change_streams: exclude_txn_from_change_streams,
-              read_lock_mode: read_lock_mode,
-              transaction_tag: transaction_tag
+              read_lock_mode: read_lock_mode || @read_lock_mode,
+              transaction_tag: transaction_tag,
+              isolation_level: isolation_level || @isolation_level
 
             begin
               Thread.current[IS_TRANSACTION_RUNNING_KEY] = true

--- a/google-cloud-spanner/lib/google/cloud/spanner/project.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/project.rb
@@ -548,6 +548,22 @@ module Google
         #      Spanner will wait for a replica in the list to become available,
         #      requests may fail due to DEADLINE_EXCEEDED errors.
         #
+        # @param isolation_level [::Symbol, nil] Optional. The isolation level for the transactions. Can be
+        #   overridden by the isolation level set on the transaction.
+        #   Can be one of the following:
+        #   * `:ISOLATION_LEVEL_UNSPECIFIED` : The default unspecified isolation level.
+        #   * `:SERIALIZABLE` : The serializable isolation level.
+        #   * `:REPEATABLE_READ` : The repeatable read isolation level.
+        # @param read_lock_mode [::Symbol, nil] Optional. The read lock mode for the transactions. Can be
+        #   overridden by the read lock mode set on the transaction.
+        #   Can be one of the following:
+        #   * `:READ_LOCK_MODE_UNSPECIFIED` : The default unspecified read lock mode.
+        #   * `:PESSIMISTIC` : The pessimistic lock mode, where depending on the isolation level and/or lock
+        #       requested, locks are acquired on read.
+        #   * `:OPTIMISTIC` : The optimistic lock mode, where locks are not acquired on read. Depending on the
+        #       isolation level and/or lock requested on a read, data may be validated at commit time to be not
+        #       changed since the transaction started.
+        #
         # @return [::Google::Cloud::Spanner::Client] The newly created client.
         #
         # @example
@@ -566,7 +582,8 @@ module Google
         #   end
         #
         def client instance_id, database_id, pool: {}, labels: nil,
-                   query_options: nil, database_role: nil, directed_read_options: nil
+                   query_options: nil, database_role: nil, directed_read_options: nil,
+                   isolation_level: nil, read_lock_mode: nil
           # Convert from possible Google::Protobuf::Map
           labels = labels.to_h { |k, v| [String(k), String(v)] } if labels
           # Configs set by environment variables take over client-level configs.
@@ -582,7 +599,9 @@ module Google
                      session_labels: labels,
                      query_options: query_options,
                      database_role: database_role,
-                     directed_read_options: directed_read_options
+                     directed_read_options: directed_read_options,
+                     isolation_level: isolation_level,
+                     read_lock_mode: read_lock_mode
         end
 
         ##

--- a/google-cloud-spanner/lib/google/cloud/spanner/service.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/service.rb
@@ -640,6 +640,19 @@ module Google
         #   An id of the previous transaction, if this new transaction wrapper is being created
         #   as a part of a retry. Previous transaction id should be added to TransactionOptions
         #   of a new ReadWrite transaction when retry is attempted.
+        # @param read_lock_mode [::Symbol, nil] Optional. The read lock mode for the transaction.
+        #   Can be one of the following:
+        #   * `:READ_LOCK_MODE_UNSPECIFIED` : The default unspecified read lock mode.
+        #   * `:PESSIMISTIC` : The pessimistic lock mode, where depending on the isolation level and/or lock
+        #       requested, locks are acquired on read.
+        #   * `:OPTIMISTIC` : The optimistic lock mode, where locks are not acquired on read. Depending on the
+        #       isolation level and/or lock requested on a read, data may be validated at commit time to be not
+        #       changed since the transaction started.
+        # @param isolation_level [::Symbol, nil] Optional. The isolation level for the transaction.
+        #   Can be one of the following:
+        #   * `:ISOLATION_LEVEL_UNSPECIFIED` : The default unspecified isolation level.
+        #   * `:SERIALIZABLE` : The serializable isolation level.
+        #   * `:REPEATABLE_READ` : The repeatable read isolation level.
         # @private
         # @return [::Google::Cloud::Spanner::V1::Transaction]
         def begin_transaction session_name,
@@ -649,7 +662,8 @@ module Google
                               route_to_leader: nil,
                               mutation_key: nil,
                               previous_transaction_id: nil,
-                              read_lock_mode: nil
+                              read_lock_mode: nil,
+                              isolation_level: nil
           read_write = if previous_transaction_id.nil?
                          V1::TransactionOptions::ReadWrite.new
                        else
@@ -664,7 +678,8 @@ module Google
 
           tx_opts = V1::TransactionOptions.new(
             read_write: read_write,
-            exclude_txn_from_change_streams: exclude_txn_from_change_streams
+            exclude_txn_from_change_streams: exclude_txn_from_change_streams,
+            isolation_level: isolation_level
           )
 
           opts = default_options session_name: session_name,

--- a/google-cloud-spanner/lib/google/cloud/spanner/session.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/session.rb
@@ -1521,13 +1521,26 @@ module Google
         #   of a new ReadWrite transaction when retry is attempted.
         # @param transaction_tag [::String, nil] Optional.
         #   A tag used for statistics collection about this transaction.
+        # @param read_lock_mode [::Symbol, nil] Optional. The read lock mode for the transaction.
+        #   Can be one of the following:
+        #   * `:READ_LOCK_MODE_UNSPECIFIED` : The default unspecified read lock mode.
+        #   * `:PESSIMISTIC` : The pessimistic lock mode, where depending on the isolation level and/or lock
+        #       requested, locks are acquired on read.
+        #   * `:OPTIMISTIC` : The optimistic lock mode, where locks are not acquired on read. Depending on the
+        #       isolation level and/or lock requested on a read, data may be validated at commit time to be not
+        #       changed since the transaction started.
+        # @param isolation_level [::Symbol, nil] Optional. The isolation level for the transaction.
+        #   Can be one of the following:
+        #   * `:ISOLATION_LEVEL_UNSPECIFIED` : The default unspecified isolation level.
+        #   * `:SERIALIZABLE` : The serializable isolation level.
+        #   * `:REPEATABLE_READ` : The repeatable read isolation level.
         # @private
         # @return [::Google::Cloud::Spanner::Transaction] The new *empty-wrapper* transaction object.
         def create_empty_transaction exclude_txn_from_change_streams: false, previous_transaction_id: nil,
-                                     read_lock_mode: nil, transaction_tag: nil
+                                     read_lock_mode: nil, transaction_tag: nil, isolation_level: nil
           Transaction.from_grpc nil, self, exclude_txn_from_change_streams: exclude_txn_from_change_streams,
                                 previous_transaction_id: previous_transaction_id, read_lock_mode: read_lock_mode,
-                                transaction_tag: transaction_tag
+                                transaction_tag: transaction_tag, isolation_level: isolation_level
         end
 
         # If the session is non-multiplexed, keeps the session alive by executing `"SELECT 1"`.

--- a/google-cloud-spanner/lib/google/cloud/spanner/transaction.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/transaction.rb
@@ -129,12 +129,13 @@ module Google
         # @private
         # @return [::Google::Cloud::Spanner::Transaction]
         def initialize grpc, session, exclude_txn_from_change_streams, previous_transaction_id: nil,
-                       read_lock_mode: nil, transaction_tag: nil
+                       read_lock_mode: nil, transaction_tag: nil, isolation_level: nil
           @grpc = grpc
           @session = session
           @exclude_txn_from_change_streams = exclude_txn_from_change_streams
           @read_lock_mode = read_lock_mode
           @transaction_tag = transaction_tag
+          @isolation_level = isolation_level
 
           # throwing away empty strings for simplicity
           unless previous_transaction_id.nil? || previous_transaction_id.empty?
@@ -144,7 +145,6 @@ module Google
           @commit = Commit.new
           @seqno = 0
           @exclude_txn_from_change_streams = false
-          @read_lock_mode = nil
 
           # Mutex to enfore thread safety for transaction creation and query executions.
           #
@@ -1259,12 +1259,25 @@ module Google
         #   of a new ReadWrite transaction when retry is attempted.
         # @param transaction_tag [::String, nil] Optional.
         #   A tag used for statistics collection about this transaction.
+        # @param read_lock_mode [::Symbol, nil] Optional. The read lock mode for the transaction.
+        #   Can be one of the following:
+        #   * `:READ_LOCK_MODE_UNSPECIFIED` : The default unspecified read lock mode.
+        #   * `:PESSIMISTIC` : The pessimistic lock mode, where depending on the isolation level and/or lock
+        #       requested, locks are acquired on read.
+        #   * `:OPTIMISTIC` : The optimistic lock mode, where locks are not acquired on read. Depending on the
+        #       isolation level and/or lock requested on a read, data may be validated at commit time to be not
+        #       changed since the transaction started.
+        # @param isolation_level [::Symbol, nil] Optional. The isolation level for the transaction.
+        #   Can be one of the following:
+        #   * `:ISOLATION_LEVEL_UNSPECIFIED` : The default unspecified isolation level.
+        #   * `:SERIALIZABLE` : The serializable isolation level.
+        #   * `:REPEATABLE_READ` : The repeatable read isolation level.
         # @private
         # @return [::Google::Cloud::Spanner::Transaction]
         def self.from_grpc grpc, session, exclude_txn_from_change_streams: false, previous_transaction_id: nil,
-                           read_lock_mode: nil, transaction_tag: nil
+                           read_lock_mode: nil, transaction_tag: nil, isolation_level: nil
           new grpc, session, exclude_txn_from_change_streams, previous_transaction_id: previous_transaction_id,
-              read_lock_mode: read_lock_mode, transaction_tag: transaction_tag
+              read_lock_mode: read_lock_mode, transaction_tag: transaction_tag, isolation_level: isolation_level
         end
 
         ##
@@ -1288,11 +1301,24 @@ module Google
         #   Example option: `:priority`.
         # @param call_options [::Hash, nil] Optional. A hash of values to specify the custom
         #   call options. Example option `:timeout`.
+        # @param read_lock_mode [::Symbol, nil] Optional. The read lock mode for the transaction.
+        #   Can be one of the following:
+        #   * `:READ_LOCK_MODE_UNSPECIFIED` : The default unspecified read lock mode.
+        #   * `:PESSIMISTIC` : The pessimistic lock mode, where depending on the isolation level and/or lock
+        #       requested, locks are acquired on read.
+        #   * `:OPTIMISTIC` : The optimistic lock mode, where locks are not acquired on read. Depending on the
+        #       isolation level and/or lock requested on a read, data may be validated at commit time to be not
+        #       changed since the transaction started.
+        # @param isolation_level [::Symbol, nil] Optional. The isolation level for the transaction.
+        #   Can be one of the following:
+        #   * `:ISOLATION_LEVEL_UNSPECIFIED` : The default unspecified isolation level.
+        #   * `:SERIALIZABLE` : The serializable isolation level.
+        #   * `:REPEATABLE_READ` : The repeatable read isolation level.
         # @private
         # @return [::Google::Cloud::Spanner::V1::Transaction, nil] The new transaction
         #   object, or `nil` if a transaction already exists.
         def safe_begin_transaction! exclude_from_change_streams: false, request_options: nil, call_options: nil,
-                                    read_lock_mode: nil
+                                    read_lock_mode: nil, isolation_level: nil
           # If a read-write transaction on a multiplexed session commit mutations
           # without performing any reads or queries, one of the mutations from the mutation set
           # must be sent as a mutation key for `BeginTransaction`.
@@ -1315,7 +1341,8 @@ module Google
               route_to_leader: route_to_leader,
               mutation_key: mutation_key,
               previous_transaction_id: previous_transaction_id,
-              read_lock_mode: read_lock_mode
+              read_lock_mode: read_lock_mode || @read_lock_mode,
+              isolation_level: isolation_level || @isolation_level
             )
           end
         end
@@ -1357,9 +1384,24 @@ module Google
         # @param exclude_txn_from_change_streams [::Boolean] Optional. Defaults to `false`.
         #   When `exclude_txn_from_change_streams` is set to `true`, it prevents read
         #   or write transactions from being tracked in change streams.
+        # @param read_lock_mode [::Symbol, nil] Optional. The read lock mode for the transaction. If not
+        #   specified, the client-level read lock mode will be used.
+        #   Can be one of the following:
+        #   * `:READ_LOCK_MODE_UNSPECIFIED` : The default unspecified read lock mode.
+        #   * `:PESSIMISTIC` : The pessimistic lock mode, where depending on the isolation level and/or lock
+        #       requested, locks are acquired on read.
+        #   * `:OPTIMISTIC` : The optimistic lock mode, where locks are not acquired on read. Depending on the
+        #       isolation level and/or lock requested on a read, data may be validated at commit time to be not
+        #       changed since the transaction started.
+        # @param isolation_level [::Symbol, nil] Optional. The isolation level for the transaction. If not
+        #   specified, the client-level isolation level will be used.
+        #   Can be one of the following:
+        #   * `:ISOLATION_LEVEL_UNSPECIFIED` : The default unspecified isolation level.
+        #   * `:SERIALIZABLE` : The serializable isolation level.
+        #   * `:REPEATABLE_READ` : The repeatable read isolation level.
         # @private
         # @return [::Google::Cloud::Spanner::V1::TransactionSelector]
-        def tx_selector exclude_txn_from_change_streams: false, read_lock_mode: nil
+        def tx_selector exclude_txn_from_change_streams: false, read_lock_mode: nil, isolation_level: nil
           return V1::TransactionSelector.new id: transaction_id if existing_transaction?
 
           read_write = if @previous_transaction_id.nil?
@@ -1370,14 +1412,16 @@ module Google
                          )
                        end
 
-          unless read_lock_mode.nil?
-            read_write.read_lock_mode = read_lock_mode
+          read_lock = read_lock_mode || @read_lock_mode
+          unless read_lock.nil?
+            read_write.read_lock_mode = read_lock
           end
 
           V1::TransactionSelector.new(
             begin: V1::TransactionOptions.new(
               read_write: read_write,
-              exclude_txn_from_change_streams: exclude_txn_from_change_streams
+              exclude_txn_from_change_streams: exclude_txn_from_change_streams,
+              isolation_level: isolation_level || @isolation_level
             )
           )
         end

--- a/google-cloud-spanner/test/google/cloud/spanner/client/commit_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/commit_test.rb
@@ -790,6 +790,121 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     end
   end
 
+  describe "client-level isolation level" do
+    let(:client_with_isolation) { spanner.client instance_id, database_id, isolation_level: :SERIALIZABLE }
+    let(:tx_opts_serializable) {
+      Google::Cloud::Spanner::V1::TransactionOptions.new read_write: Google::Cloud::Spanner::V1::TransactionOptions::ReadWrite.new,
+                                                         isolation_level: Google::Cloud::Spanner::V1::TransactionOptions::IsolationLevel::SERIALIZABLE
+    }
+    let(:tx_opts_repeatable_read) {
+      Google::Cloud::Spanner::V1::TransactionOptions.new read_write: Google::Cloud::Spanner::V1::TransactionOptions::ReadWrite.new,
+                                                         isolation_level: Google::Cloud::Spanner::V1::TransactionOptions::IsolationLevel::REPEATABLE_READ
+    }
+
+    it "uses client-level isolation level in delete" do
+      mutations = [
+        Google::Cloud::Spanner::V1::Mutation.new(
+          delete: Google::Cloud::Spanner::V1::Mutation::Delete.new(
+            table: "users", key_set: Google::Cloud::Spanner::V1::KeySet.new(all: true)
+          )
+        )
+      ]
+
+      mock = Minitest::Mock.new
+      mock.expect :create_session, session_grpc, [{database: database_path(instance_id, database_id), session: default_session_request}, default_options]
+      mock.expect :commit, commit_resp, [{ session: session_grpc.name, mutations: mutations, transaction_id: nil, single_use_transaction: tx_opts_serializable, request_options: nil, precommit_token: nil }, default_options]
+      spanner.service.mocked_service = mock
+
+      timestamp = client_with_isolation.delete "users"
+      _(timestamp).must_equal commit_time
+
+      shutdown_client! client_with_isolation
+      mock.verify
+    end
+
+    it "overrides client-level isolation level in delete" do
+      mutations = [
+        Google::Cloud::Spanner::V1::Mutation.new(
+          delete: Google::Cloud::Spanner::V1::Mutation::Delete.new(
+            table: "users", key_set: Google::Cloud::Spanner::V1::KeySet.new(all: true)
+          )
+        )
+      ]
+
+      mock = Minitest::Mock.new
+      mock.expect :create_session, session_grpc, [{database: database_path(instance_id, database_id), session: default_session_request}, default_options]
+      mock.expect :commit, commit_resp, [{ session: session_grpc.name, mutations: mutations, transaction_id: nil, single_use_transaction: tx_opts_repeatable_read, request_options: nil, precommit_token: nil }, default_options]
+      spanner.service.mocked_service = mock
+
+      timestamp = client_with_isolation.delete "users", isolation_level: Google::Cloud::Spanner::V1::TransactionOptions::IsolationLevel::REPEATABLE_READ
+      _(timestamp).must_equal commit_time
+
+      shutdown_client! client_with_isolation
+      mock.verify
+    end
+  end
+
+  describe "client-level read lock mode" do
+    let(:read_lock_optimistic) { Google::Cloud::Spanner::V1::TransactionOptions::ReadWrite::ReadLockMode::OPTIMISTIC }
+    let(:read_lock_pessimistic) { Google::Cloud::Spanner::V1::TransactionOptions::ReadWrite::ReadLockMode::PESSIMISTIC }
+    let(:tx_opts_optimistic) do
+      Google::Cloud::Spanner::V1::TransactionOptions.new(
+        read_write: Google::Cloud::Spanner::V1::TransactionOptions::ReadWrite.new(read_lock_mode: read_lock_optimistic)
+      )
+    end
+    let(:tx_opts_pessimistic) do
+      Google::Cloud::Spanner::V1::TransactionOptions.new(
+        read_write: Google::Cloud::Spanner::V1::TransactionOptions::ReadWrite.new(read_lock_mode: read_lock_pessimistic)
+      )
+    end
+
+    it "uses client-level read lock mode in commit" do
+      client_with_read_lock = spanner.client instance_id, database_id, read_lock_mode: :OPTIMISTIC
+
+      mutations = [
+        Google::Cloud::Spanner::V1::Mutation.new(
+          delete: Google::Cloud::Spanner::V1::Mutation::Delete.new(
+            table: "users", key_set: Google::Cloud::Spanner::V1::KeySet.new(all: true)
+          )
+        )
+      ]
+
+      mock = Minitest::Mock.new
+      mock.expect :create_session, session_grpc, [{database: database_path(instance_id, database_id), session: default_session_request}, default_options]
+      mock.expect :commit, commit_resp, [{ session: session_grpc.name, mutations: mutations, transaction_id: nil, single_use_transaction: tx_opts_optimistic, request_options: nil, precommit_token: nil }, default_options]
+      spanner.service.mocked_service = mock
+
+      timestamp = client_with_read_lock.delete "users"
+      _(timestamp).must_equal commit_time
+
+      shutdown_client! client_with_read_lock
+      mock.verify
+    end
+
+    it "overrides client-level read lock mode in commit" do
+      client_with_read_lock = spanner.client instance_id, database_id, read_lock_mode: :OPTIMISTIC
+
+      mutations = [
+        Google::Cloud::Spanner::V1::Mutation.new(
+          delete: Google::Cloud::Spanner::V1::Mutation::Delete.new(
+            table: "users", key_set: Google::Cloud::Spanner::V1::KeySet.new(all: true)
+          )
+        )
+      ]
+
+      mock = Minitest::Mock.new
+      mock.expect :create_session, session_grpc, [{database: database_path(instance_id, database_id), session: default_session_request}, default_options]
+      mock.expect :commit, commit_resp, [{ session: session_grpc.name, mutations: mutations, transaction_id: nil, single_use_transaction: tx_opts_pessimistic, request_options: nil, precommit_token: nil }, default_options]
+      spanner.service.mocked_service = mock
+
+      timestamp = client_with_read_lock.delete "users", read_lock_mode: :PESSIMISTIC
+      _(timestamp).must_equal commit_time
+
+      shutdown_client! client_with_read_lock
+      mock.verify
+    end
+  end
+
   def mock_commit_request mutations, request_options: nil
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [{

--- a/google-cloud-spanner/test/google/cloud/spanner/client/transaction_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/transaction_test.rb
@@ -684,6 +684,226 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
     mock.verify
   end
 
+  it "deletes while setting isolation level" do
+    mutations = [
+      Google::Cloud::Spanner::V1::Mutation.new(
+        delete: Google::Cloud::Spanner::V1::Mutation::Delete.new(
+          table: "users", key_set: Google::Cloud::Spanner::V1::KeySet.new(all: true)
+        )
+      )
+    ]
+
+    tx_opts_isolation = Google::Cloud::Spanner::V1::TransactionOptions.new(
+      read_write: Google::Cloud::Spanner::V1::TransactionOptions::ReadWrite.new,
+      isolation_level: Google::Cloud::Spanner::V1::TransactionOptions::IsolationLevel::SERIALIZABLE
+    )
+
+    mock = Minitest::Mock.new
+    mock.expect :create_session, session_grpc, [{ database: database_path(instance_id, database_id), session: default_session_request }, default_options]
+    mock.expect :begin_transaction, transaction_grpc, [{
+        session: session_grpc.name,
+        options: tx_opts_isolation, 
+        request_options: nil,
+        mutation_key: mutations[0]
+      }, default_options]
+
+    mock.expect :commit, commit_resp, [{
+      session: session_grpc.name, 
+      mutations: mutations, 
+      transaction_id: transaction_id, 
+      single_use_transaction: nil, precommit_token: nil,
+      request_options: nil
+    }, default_options]
+    spanner.service.mocked_service = mock
+
+    timestamp = client.transaction(isolation_level: :SERIALIZABLE) do |tx|
+      tx.delete "users"
+    end
+    _(timestamp).must_equal commit_time
+
+    shutdown_client! client
+
+    mock.verify
+  end
+
+  it "uses client-level isolation level in transaction" do
+    client_with_isolation = spanner.client instance_id, database_id, isolation_level: :SERIALIZABLE
+
+    mutations = [
+      Google::Cloud::Spanner::V1::Mutation.new(
+        delete: Google::Cloud::Spanner::V1::Mutation::Delete.new(
+          table: "users", key_set: Google::Cloud::Spanner::V1::KeySet.new(all: true)
+        )
+      )
+    ]
+
+    tx_opts_isolation = Google::Cloud::Spanner::V1::TransactionOptions.new(
+      read_write: Google::Cloud::Spanner::V1::TransactionOptions::ReadWrite.new,
+      isolation_level: Google::Cloud::Spanner::V1::TransactionOptions::IsolationLevel::SERIALIZABLE
+    )
+
+    mock = Minitest::Mock.new
+    mock.expect :create_session, session_grpc, [{ database: database_path(instance_id, database_id), session: default_session_request }, default_options]
+    mock.expect :begin_transaction, transaction_grpc, [{
+        session: session_grpc.name,
+        options: tx_opts_isolation,
+        request_options: nil,
+        mutation_key: mutations[0]
+      }, default_options]
+
+    mock.expect :commit, commit_resp, [{
+      session: session_grpc.name, 
+      mutations: mutations, 
+      transaction_id: transaction_id, 
+      single_use_transaction: nil, precommit_token: nil,
+      request_options: nil
+    }, default_options]
+    spanner.service.mocked_service = mock
+
+    timestamp = client_with_isolation.transaction do |tx|
+      tx.delete "users"
+    end
+    _(timestamp).must_equal commit_time
+
+    shutdown_client! client_with_isolation
+
+    mock.verify
+  end
+
+  it "overrides client-level isolation level in transaction" do
+    client_with_isolation = spanner.client instance_id, database_id, isolation_level: :SERIALIZABLE
+
+    mutations = [
+      Google::Cloud::Spanner::V1::Mutation.new(
+        delete: Google::Cloud::Spanner::V1::Mutation::Delete.new(
+          table: "users", key_set: Google::Cloud::Spanner::V1::KeySet.new(all: true)
+        )
+      )
+    ]
+
+    tx_opts_repeatable = Google::Cloud::Spanner::V1::TransactionOptions.new(
+      read_write: Google::Cloud::Spanner::V1::TransactionOptions::ReadWrite.new,
+      isolation_level: Google::Cloud::Spanner::V1::TransactionOptions::IsolationLevel::REPEATABLE_READ
+    )
+
+    mock = Minitest::Mock.new
+    mock.expect :create_session, session_grpc, [{ database: database_path(instance_id, database_id), session: default_session_request }, default_options]
+    mock.expect :begin_transaction, transaction_grpc, [{
+        session: session_grpc.name,
+        options: tx_opts_repeatable, 
+        request_options: nil,
+        mutation_key: mutations[0]
+      }, default_options]
+
+    mock.expect :commit, commit_resp, [{
+      session: session_grpc.name, 
+      mutations: mutations, 
+      transaction_id: transaction_id, 
+      single_use_transaction: nil, precommit_token: nil,
+      request_options: nil
+    }, default_options]
+    spanner.service.mocked_service = mock
+
+    timestamp = client_with_isolation.transaction(isolation_level: :REPEATABLE_READ) do |tx|
+      tx.delete "users"
+    end
+    _(timestamp).must_equal commit_time
+
+    shutdown_client! client_with_isolation
+
+    mock.verify
+  end
+
+  it "uses client-level read lock mode in transaction" do
+    client_with_read_lock = spanner.client instance_id, database_id, read_lock_mode: :OPTIMISTIC
+
+    mutations = [
+      Google::Cloud::Spanner::V1::Mutation.new(
+        delete: Google::Cloud::Spanner::V1::Mutation::Delete.new(
+          table: "users", key_set: Google::Cloud::Spanner::V1::KeySet.new(all: true)
+        )
+      )
+    ]
+
+    tx_opts_optimistic = Google::Cloud::Spanner::V1::TransactionOptions.new(
+      read_write: Google::Cloud::Spanner::V1::TransactionOptions::ReadWrite.new(
+        read_lock_mode: Google::Cloud::Spanner::V1::TransactionOptions::ReadWrite::ReadLockMode::OPTIMISTIC
+      )
+    )
+
+    mock = Minitest::Mock.new
+    mock.expect :create_session, session_grpc, [{ database: database_path(instance_id, database_id), session: default_session_request }, default_options]
+    mock.expect :begin_transaction, transaction_grpc, [{
+        session: session_grpc.name,
+        options: tx_opts_optimistic,
+        request_options: nil,
+        mutation_key: mutations[0]
+      }, default_options]
+
+    mock.expect :commit, commit_resp, [{
+      session: session_grpc.name,
+      mutations: mutations,
+      transaction_id: transaction_id,
+      single_use_transaction: nil, precommit_token: nil,
+      request_options: nil
+    }, default_options]
+    spanner.service.mocked_service = mock
+
+    timestamp = client_with_read_lock.transaction do |tx|
+      tx.delete "users"
+    end
+    _(timestamp).must_equal commit_time
+
+    shutdown_client! client_with_read_lock
+
+    mock.verify
+  end
+
+  it "overrides client-level read lock mode in transaction" do
+    client_with_read_lock = spanner.client instance_id, database_id, read_lock_mode: :OPTIMISTIC
+
+    mutations = [
+      Google::Cloud::Spanner::V1::Mutation.new(
+        delete: Google::Cloud::Spanner::V1::Mutation::Delete.new(
+          table: "users", key_set: Google::Cloud::Spanner::V1::KeySet.new(all: true)
+        )
+      )
+    ]
+
+    tx_opts_pessimistic = Google::Cloud::Spanner::V1::TransactionOptions.new(
+      read_write: Google::Cloud::Spanner::V1::TransactionOptions::ReadWrite.new(
+        read_lock_mode: Google::Cloud::Spanner::V1::TransactionOptions::ReadWrite::ReadLockMode::PESSIMISTIC
+      )
+    )
+
+    mock = Minitest::Mock.new
+    mock.expect :create_session, session_grpc, [{ database: database_path(instance_id, database_id), session: default_session_request }, default_options]
+    mock.expect :begin_transaction, transaction_grpc, [{
+        session: session_grpc.name,
+        options: tx_opts_pessimistic,
+        request_options: nil,
+        mutation_key: mutations[0]
+      }, default_options]
+
+    mock.expect :commit, commit_resp, [{
+      session: session_grpc.name,
+      mutations: mutations,
+      transaction_id: transaction_id,
+      single_use_transaction: nil, precommit_token: nil,
+      request_options: nil
+    }, default_options]
+    spanner.service.mocked_service = mock
+
+    timestamp = client_with_read_lock.transaction(read_lock_mode: Google::Cloud::Spanner::V1::TransactionOptions::ReadWrite::ReadLockMode::PESSIMISTIC) do |tx|
+      tx.delete "users"
+    end
+    _(timestamp).must_equal commit_time
+
+    shutdown_client! client_with_read_lock
+
+    mock.verify
+  end
+
   it "commits multiple mutations" do
     mutations = [
       Google::Cloud::Spanner::V1::Mutation.new(


### PR DESCRIPTION
Adds support for setting the isolation level and read lock mode at the client-level. If the options are set at a client-level, they're added to transaction options when creating a RW transaction. The client-level value can be overridden by setting the isolation level and/or read lock mode at the transaction-level.