### PR TITLE
chore(ci): pin action versions and upgrade node to 24.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,8 @@
 name: CI
+
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches:
@@ -51,20 +55,26 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        persist-credentials: false
     - name: Install Ruby ${{ matrix.ruby }}
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0
       with:
         ruby-version: "${{ matrix.ruby }}"
-    - name: Install NodeJS 18.x
-      uses: actions/setup-node@v6
+    - name: Install NodeJS 24.x
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: "24.x"
     - name: Install tools
       run: "gem install --no-document toys && npm install linkinator"
     - name: Test ${{ matrix.task }}
+      env:
+        GITHUB_EVENT_NAME: ${{ github.event_name }}
+        GITHUB_EVENT_PATH: ${{ github.event_path }}
+        EXTRA_FLAGS: ${{ github.event.inputs.flags }}
       run: |
-        toys ci -v ${{ matrix.task }} --github-event-name=${{ github.event_name }} --github-event-payload=${{ github.event_path }} ${{ github.event.inputs.flags }}
+        toys ci -v ${{ matrix.task }} --github-event-name="$GITHUB_EVENT_NAME" --github-event-payload="$GITHUB_EVENT_PATH" $EXTRA_FLAGS
     - name: Open Issues
       if: ${{ failure() }}
       env:

--- a/.github/workflows/spanner-integration-tests-against-emulator.yaml
+++ b/.github/workflows/spanner-integration-tests-against-emulator.yaml
@@ -1,3 +1,8 @@
+name: Run Spanner integration tests against service emulator
+
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -7,7 +12,6 @@ on:
   pull_request:
     paths:
       - 'google-cloud-spanner*/**'
-name: Run Spanner integration tests against service emulator
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -24,8 +28,10 @@ jobs:
           - 9020:9020
 
     steps:
-      - uses: actions/checkout@v6
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0
         with:
           ruby-version: '4.0.5'
       - run: ruby --version


### PR DESCRIPTION
Used go/github-zizmor-help?polyglot=github-com#local-scans-run-zizmor-on-your-cloudtop