### PR TITLE
chore: Add JUnit XML reporting to Spanner veneer test suites

### DIFF
--- a/google-cloud-spanner/.gitignore
+++ b/google-cloud-spanner/.gitignore
@@ -7,3 +7,7 @@ jsondoc/*
 
 # Ignore YARD stuffs
 .yardoc
+
+# Ignore transient test outputs
+tmp
+

--- a/google-cloud-spanner/Gemfile
+++ b/google-cloud-spanner/Gemfile
@@ -16,7 +16,9 @@ gem "irb", "~> 1.17"
 gem "minitest", "~> 5.25"
 gem "minitest-autotest", "~> 1.0"
 gem "minitest-focus", "~> 1.4"
+gem "minitest-reporters", "~> 1.7"
 gem "minitest-rg", "~> 5.3"
+
 gem "mutex_m", "~> 0.3.0"
 gem "pry", group: :development, require: false
 gem "rake"

--- a/google-cloud-spanner/Gemfile.lock
+++ b/google-cloud-spanner/Gemfile.lock
@@ -14,12 +14,14 @@ GEM
   specs:
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
+    ansi (1.6.0)
     ast (2.4.3)
     autotest-suffix (1.1.0)
     backport (1.2.0)
     base64 (0.3.0)
     benchmark (0.5.0)
     bigdecimal (3.3.1)
+    builder (3.3.0)
     coderay (1.1.3)
     concurrent-ruby (1.3.7)
     date (3.5.1)
@@ -151,6 +153,11 @@ GEM
       path_expander (~> 2.0)
     minitest-focus (1.4.1)
       minitest (> 5.0)
+    minitest-reporters (1.8.0)
+      ansi
+      builder
+      minitest (>= 5.0, < 7)
+      ruby-progressbar
     minitest-rg (5.4.0)
       minitest (>= 5.0, < 7)
     minitest-server (1.0.10)
@@ -307,6 +314,7 @@ DEPENDENCIES
   minitest (~> 5.25)
   minitest-autotest (~> 1.0)
   minitest-focus (~> 1.4)
+  minitest-reporters (~> 1.7)
   minitest-rg (~> 5.3)
   mutex_m (~> 0.3.0)
   pry
@@ -319,12 +327,14 @@ DEPENDENCIES
 
 CHECKSUMS
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
+  ansi (1.6.0)
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   autotest-suffix (1.1.0) sha256=9bb29331b7b66a9659b01ef10839bd61fc1a6e95477c8ea710bd01e10c380977
   backport (1.2.0) sha256=912c7dfdd9ee4625d013ddfccb6205c3f92da69a8990f65c440e40f5b2fc7f75
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   benchmark (0.5.0) sha256=465df122341aedcb81a2a24b4d3bd19b6c67c1530713fd533f3ff034e419236c
   bigdecimal (3.3.1) sha256=eaa01e228be54c4f9f53bf3cc34fe3d5e845c31963e7fcc5bedb05a4e7d52218
+  builder (3.3.0)
   bundler (4.0.12) sha256=7f8b757d28dfb636e7b24fba2344ac6dd13b5b24f4b46d62573d483f211825ac
   coderay (1.1.3) sha256=dc530018a4684512f8f38143cd2a096c9f02a1fc2459edcfe534787a7fc77d4b
   concurrent-ruby (1.3.7) sha256=4412caec3a5ea2e5fdc52076724c071a81f2c0593d83b2ac8cbb8ca63b3151b0
@@ -379,6 +389,7 @@ CHECKSUMS
   minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
   minitest-autotest (1.2.0) sha256=60d031cba705215450662b0060f03f96507682b346a19c27f6756751ad92d2b4
   minitest-focus (1.4.1) sha256=394517cbe2dcb2d992d8ffc41a3b2b6315777a4daa69239de4fefe7110dd810e
+  minitest-reporters (1.8.0)
   minitest-rg (5.4.0) sha256=54d42bb8ce876381245be5866f3c1dd704ef79c06ba5c9ff280c0aa28c56effb
   minitest-server (1.0.10) sha256=275439bf3ffc433fcbe161733248f1d9749ebf122892cf010bf864aaa95cef75
   multi_json (1.21.1) sha256=e6126a31808e3b4d19f483c775ceac34df190dffa62adfb63a165ee14ba68080

--- a/google-cloud-spanner/acceptance/spanner_helper.rb
+++ b/google-cloud-spanner/acceptance/spanner_helper.rb
@@ -18,6 +18,19 @@ gem "minitest"
 require "minitest/autorun"
 require "minitest/focus"
 
+if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
+  # Load the shared JUnit preloader from googleapis/ruby-common-tools to format
+  # minitest output as JUnit XML (writing to tmp/reports/sponge_log.xml).
+  # This enables test result indexing and health tracking on TestGrid dashboards.
+  begin
+    require "gapic/minitest_junit_preloader"
+  rescue LoadError
+    # Fallback when running outside of Kokoro task environments without the preloader
+  end
+end
+
+
+
 require "google/cloud/spanner"
 require "google/cloud/spanner/admin/database"
 

--- a/google-cloud-spanner/test/helper.rb
+++ b/google-cloud-spanner/test/helper.rb
@@ -18,6 +18,19 @@ gem "minitest"
 require "minitest/autorun"
 require "minitest/focus"
 require "minitest/rg"
+
+if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
+  # Load the shared JUnit preloader from googleapis/ruby-common-tools to format
+  # minitest output as JUnit XML (writing to tmp/reports/sponge_log.xml).
+  # This enables test result indexing and health tracking on TestGrid dashboards.
+  begin
+    require "gapic/minitest_junit_preloader"
+  rescue LoadError
+    # Fallback when running outside of Kokoro task environments without the preloader
+  end
+end
+
+
 require "ostruct"
 require "json"
 require "base64"


### PR DESCRIPTION
Write minitest execution output to JUnit XML reports. This enables centralized test result indexing, flake tracing, and build health metrics reporting inside TestGrid dashboards.